### PR TITLE
Fix Poetry install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "axon"
 version = "0.1.0"
 description = "Axon Project"
 authors = ["Your Name <you@example.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
## Summary
- disable package mode in pyproject so `poetry install` works without a package directory

## Testing
- `poetry run ruff .`
- `poetry run mypy .`
- `poetry install`


------
https://chatgpt.com/codex/tasks/task_e_687b134ea52c832bb0e48632cfdee367