### PR TITLE
Implement remote fallback workflow

### DIFF
--- a/agent/fallback_prompt.py
+++ b/agent/fallback_prompt.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+import json
+
+@dataclass
+class FallbackPrompt:
+    """Metadata for a prompt intended for a remote LLM"""
+    model: str
+    prompt: str
+    reason: str
+
+def generate_prompt(user_message: str, model: str = "gpt-4o", reason: str | None = None) -> dict:
+    """Return a dict describing a cloud prompt."""
+    if reason is None:
+        reason = "Local model may be insufficient for this request."
+    prompt = (
+        "You are Axon's remote assistant. "
+        f"Please answer the following user request:\n{user_message}"
+    )
+    return {"type": "cloud_prompt", "model": model, "prompt": prompt, "reason": reason}
+
+
+def to_json(data: dict) -> str:
+    """Serialize fallback prompt dict to JSON string."""
+    return json.dumps(data)

--- a/agent/pasteback_handler.py
+++ b/agent/pasteback_handler.py
@@ -1,0 +1,13 @@
+import time
+from memory.memory_handler import MemoryHandler
+
+class PastebackHandler:
+    """Store remote model responses in memory."""
+
+    def __init__(self, memory_handler: MemoryHandler):
+        self.memory_handler = memory_handler
+
+    def store(self, thread_id: str, prompt: str, response: str, model: str = "gpt") -> None:
+        ts = int(time.time())
+        self.memory_handler.add_fact(thread_id, f"cloud_prompt_{ts}", prompt, identity=model)
+        self.memory_handler.add_fact(thread_id, f"cloud_response_{ts}", response, identity=model)

--- a/plugins/clipboard_monitor.py
+++ b/plugins/clipboard_monitor.py
@@ -1,0 +1,29 @@
+from agent.plugin_loader import plugin
+import time
+
+try:
+    import pyperclip
+    import keyboard
+except Exception as e:  # pragma: no cover - optional dependency
+    pyperclip = None
+    keyboard = None
+
+@plugin(
+    name="clipboard_monitor",
+    description="Watch clipboard for updates for a few seconds",
+    usage="clipboard_monitor(seconds=15)"
+)
+def clipboard_monitor(seconds: int = 15):
+    """Return clipboard changes detected within the given period."""
+    if not pyperclip or not keyboard:
+        return "pyperclip and keyboard modules required"
+    end = time.time() + seconds
+    last = pyperclip.paste()
+    seen: list[str] = []
+    while time.time() < end:
+        current = pyperclip.paste()
+        if current != last:
+            seen.append(current)
+            last = current
+        time.sleep(0.5)
+    return seen

--- a/poetry.lock
+++ b/poetry.lock
@@ -465,6 +465,21 @@ files = [
 ]
 
 [[package]]
+name = "keyboard"
+version = "0.13.5"
+description = "Hook and simulate keyboard events on Windows and Linux"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "keyboard-0.13.5-py3-none-any.whl", hash = "sha256:8e9c2422f1217e0bd84489b9ecd361027cc78415828f4fe4f88dd4acd587947b"},
+    {file = "keyboard-0.13.5.zip", hash = "sha256:63ed83305955939ca5c9a73755e5cc43e8242263f5ad5fd3bb7e0b032f3d308b"},
+]
+
+[package.dependencies]
+pyobjc = {version = "*", markers = "sys_platform == \"darwin\""}
+
+[[package]]
 name = "mypy"
 version = "1.17.0"
 description = "Optional static typing for Python"
@@ -988,6 +1003,3608 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyobjc"
+version = "11.1"
+description = "Python<->ObjC Interoperability Module"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc-11.1-py3-none-any.whl", hash = "sha256:903f822cba40be53d408b8eaf834514937ec0b4e6af1c5ecc24fcb652812dd85"},
+    {file = "pyobjc-11.1.tar.gz", hash = "sha256:a71b14389657811d658526ba4d5faba4ef7eadbddcf9fe8bf4fb3a6261effba3"},
+]
+
+[package.dependencies]
+pyobjc-core = "11.1"
+pyobjc-framework-Accessibility = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Accounts = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-AddressBook = "11.1"
+pyobjc-framework-AdServices = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-AdSupport = {version = "11.1", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-AppleScriptKit = "11.1"
+pyobjc-framework-AppleScriptObjC = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-ApplicationServices = "11.1"
+pyobjc-framework-AppTrackingTransparency = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-AudioVideoBridging = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-AuthenticationServices = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-AutomaticAssessmentConfiguration = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Automator = "11.1"
+pyobjc-framework-AVFoundation = {version = "11.1", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-AVKit = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-AVRouting = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-BackgroundAssets = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-BrowserEngineKit = {version = "11.1", markers = "platform_release >= \"23.4\""}
+pyobjc-framework-BusinessChat = {version = "11.1", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-CalendarStore = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-CallKit = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Carbon = "11.1"
+pyobjc-framework-CFNetwork = "11.1"
+pyobjc-framework-Cinematic = {version = "11.1", markers = "platform_release >= \"23.0\""}
+pyobjc-framework-ClassKit = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-CloudKit = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-Cocoa = "11.1"
+pyobjc-framework-Collaboration = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-ColorSync = {version = "11.1", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-Contacts = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-ContactsUI = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-CoreAudio = "11.1"
+pyobjc-framework-CoreAudioKit = "11.1"
+pyobjc-framework-CoreBluetooth = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-CoreData = "11.1"
+pyobjc-framework-CoreHaptics = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-CoreLocation = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-CoreMedia = {version = "11.1", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-CoreMediaIO = {version = "11.1", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-CoreMIDI = "11.1"
+pyobjc-framework-CoreML = {version = "11.1", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-CoreMotion = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-CoreServices = "11.1"
+pyobjc-framework-CoreSpotlight = {version = "11.1", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-CoreText = "11.1"
+pyobjc-framework-CoreWLAN = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-CryptoTokenKit = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-DataDetection = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-DeviceCheck = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-DeviceDiscoveryExtension = {version = "11.1", markers = "platform_release >= \"24.0\""}
+pyobjc-framework-DictionaryServices = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-DiscRecording = "11.1"
+pyobjc-framework-DiscRecordingUI = "11.1"
+pyobjc-framework-DiskArbitration = "11.1"
+pyobjc-framework-DVDPlayback = "11.1"
+pyobjc-framework-EventKit = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-ExceptionHandling = "11.1"
+pyobjc-framework-ExecutionPolicy = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ExtensionKit = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-ExternalAccessory = {version = "11.1", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-FileProvider = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-FileProviderUI = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-FinderSync = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-FSEvents = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-FSKit = {version = "11.1", markers = "platform_release >= \"24.4\""}
+pyobjc-framework-GameCenter = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-GameController = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-GameKit = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-GameplayKit = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-HealthKit = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-ImageCaptureCore = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-InputMethodKit = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-InstallerPlugins = "11.1"
+pyobjc-framework-InstantMessage = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-Intents = {version = "11.1", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-IntentsUI = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-IOBluetooth = "11.1"
+pyobjc-framework-IOBluetoothUI = "11.1"
+pyobjc-framework-IOSurface = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-iTunesLibrary = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-KernelManagement = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-LatentSemanticMapping = "11.1"
+pyobjc-framework-LaunchServices = "11.1"
+pyobjc-framework-libdispatch = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-libxpc = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-LinkPresentation = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-LocalAuthentication = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-LocalAuthenticationEmbeddedUI = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-MailKit = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-MapKit = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaAccessibility = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaExtension = {version = "11.1", markers = "platform_release >= \"24.0\""}
+pyobjc-framework-MediaLibrary = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaPlayer = {version = "11.1", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-MediaToolbox = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-Metal = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MetalFX = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-MetalKit = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MetalPerformanceShaders = {version = "11.1", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-MetalPerformanceShadersGraph = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-MetricKit = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-MLCompute = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-ModelIO = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MultipeerConnectivity = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-NaturalLanguage = {version = "11.1", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-NetFS = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-Network = {version = "11.1", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-NetworkExtension = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-NotificationCenter = {version = "11.1", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-OpenDirectory = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-OSAKit = "11.1"
+pyobjc-framework-OSLog = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-PassKit = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-PencilKit = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-PHASE = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-Photos = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-PhotosUI = {version = "11.1", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-PreferencePanes = "11.1"
+pyobjc-framework-PubSub = {version = "11.1", markers = "platform_release >= \"9.0\" and platform_release < \"18.0\""}
+pyobjc-framework-PushKit = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Quartz = "11.1"
+pyobjc-framework-QuickLookThumbnailing = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ReplayKit = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-SafariServices = {version = "11.1", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-SafetyKit = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-SceneKit = {version = "11.1", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-ScreenCaptureKit = {version = "11.1", markers = "platform_release >= \"21.4\""}
+pyobjc-framework-ScreenSaver = "11.1"
+pyobjc-framework-ScreenTime = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-ScriptingBridge = {version = "11.1", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-SearchKit = "11.1"
+pyobjc-framework-Security = "11.1"
+pyobjc-framework-SecurityFoundation = "11.1"
+pyobjc-framework-SecurityInterface = "11.1"
+pyobjc-framework-SecurityUI = {version = "11.1", markers = "platform_release >= \"24.4\""}
+pyobjc-framework-SensitiveContentAnalysis = {version = "11.1", markers = "platform_release >= \"23.0\""}
+pyobjc-framework-ServiceManagement = {version = "11.1", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-SharedWithYou = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-SharedWithYouCore = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-ShazamKit = {version = "11.1", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-Social = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-SoundAnalysis = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Speech = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-SpriteKit = {version = "11.1", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-StoreKit = {version = "11.1", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-Symbols = {version = "11.1", markers = "platform_release >= \"23.0\""}
+pyobjc-framework-SyncServices = "11.1"
+pyobjc-framework-SystemConfiguration = "11.1"
+pyobjc-framework-SystemExtensions = {version = "11.1", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ThreadNetwork = {version = "11.1", markers = "platform_release >= \"22.0\""}
+pyobjc-framework-UniformTypeIdentifiers = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-UserNotifications = {version = "11.1", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-UserNotificationsUI = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-VideoSubscriberAccount = {version = "11.1", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-VideoToolbox = {version = "11.1", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-Virtualization = {version = "11.1", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Vision = {version = "11.1", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-WebKit = "11.1"
+
+[package.extras]
+allbindings = ["pyobjc-core (==11.1)", "pyobjc-framework-AVFoundation (==11.1)", "pyobjc-framework-AVKit (==11.1)", "pyobjc-framework-AVRouting (==11.1)", "pyobjc-framework-Accessibility (==11.1)", "pyobjc-framework-Accounts (==11.1)", "pyobjc-framework-AdServices (==11.1)", "pyobjc-framework-AdSupport (==11.1)", "pyobjc-framework-AddressBook (==11.1)", "pyobjc-framework-AppTrackingTransparency (==11.1)", "pyobjc-framework-AppleScriptKit (==11.1)", "pyobjc-framework-AppleScriptObjC (==11.1)", "pyobjc-framework-ApplicationServices (==11.1)", "pyobjc-framework-AudioVideoBridging (==11.1)", "pyobjc-framework-AuthenticationServices (==11.1)", "pyobjc-framework-AutomaticAssessmentConfiguration (==11.1)", "pyobjc-framework-Automator (==11.1)", "pyobjc-framework-BackgroundAssets (==11.1)", "pyobjc-framework-BrowserEngineKit (==11.1)", "pyobjc-framework-BusinessChat (==11.1)", "pyobjc-framework-CFNetwork (==11.1)", "pyobjc-framework-CalendarStore (==11.1)", "pyobjc-framework-CallKit (==11.1)", "pyobjc-framework-Carbon (==11.1)", "pyobjc-framework-Cinematic (==11.1)", "pyobjc-framework-ClassKit (==11.1)", "pyobjc-framework-CloudKit (==11.1)", "pyobjc-framework-Cocoa (==11.1)", "pyobjc-framework-Collaboration (==11.1)", "pyobjc-framework-ColorSync (==11.1)", "pyobjc-framework-Contacts (==11.1)", "pyobjc-framework-ContactsUI (==11.1)", "pyobjc-framework-CoreAudio (==11.1)", "pyobjc-framework-CoreAudioKit (==11.1)", "pyobjc-framework-CoreBluetooth (==11.1)", "pyobjc-framework-CoreData (==11.1)", "pyobjc-framework-CoreHaptics (==11.1)", "pyobjc-framework-CoreLocation (==11.1)", "pyobjc-framework-CoreMIDI (==11.1)", "pyobjc-framework-CoreML (==11.1)", "pyobjc-framework-CoreMedia (==11.1)", "pyobjc-framework-CoreMediaIO (==11.1)", "pyobjc-framework-CoreMotion (==11.1)", "pyobjc-framework-CoreServices (==11.1)", "pyobjc-framework-CoreSpotlight (==11.1)", "pyobjc-framework-CoreText (==11.1)", "pyobjc-framework-CoreWLAN (==11.1)", "pyobjc-framework-CryptoTokenKit (==11.1)", "pyobjc-framework-DVDPlayback (==11.1)", "pyobjc-framework-DataDetection (==11.1)", "pyobjc-framework-DeviceCheck (==11.1)", "pyobjc-framework-DeviceDiscoveryExtension (==11.1)", "pyobjc-framework-DictionaryServices (==11.1)", "pyobjc-framework-DiscRecording (==11.1)", "pyobjc-framework-DiscRecordingUI (==11.1)", "pyobjc-framework-DiskArbitration (==11.1)", "pyobjc-framework-EventKit (==11.1)", "pyobjc-framework-ExceptionHandling (==11.1)", "pyobjc-framework-ExecutionPolicy (==11.1)", "pyobjc-framework-ExtensionKit (==11.1)", "pyobjc-framework-ExternalAccessory (==11.1)", "pyobjc-framework-FSEvents (==11.1)", "pyobjc-framework-FSKit (==11.1)", "pyobjc-framework-FileProvider (==11.1)", "pyobjc-framework-FileProviderUI (==11.1)", "pyobjc-framework-FinderSync (==11.1)", "pyobjc-framework-GameCenter (==11.1)", "pyobjc-framework-GameController (==11.1)", "pyobjc-framework-GameKit (==11.1)", "pyobjc-framework-GameplayKit (==11.1)", "pyobjc-framework-HealthKit (==11.1)", "pyobjc-framework-IOBluetooth (==11.1)", "pyobjc-framework-IOBluetoothUI (==11.1)", "pyobjc-framework-IOSurface (==11.1)", "pyobjc-framework-ImageCaptureCore (==11.1)", "pyobjc-framework-InputMethodKit (==11.1)", "pyobjc-framework-InstallerPlugins (==11.1)", "pyobjc-framework-InstantMessage (==11.1)", "pyobjc-framework-Intents (==11.1)", "pyobjc-framework-IntentsUI (==11.1)", "pyobjc-framework-KernelManagement (==11.1)", "pyobjc-framework-LatentSemanticMapping (==11.1)", "pyobjc-framework-LaunchServices (==11.1)", "pyobjc-framework-LinkPresentation (==11.1)", "pyobjc-framework-LocalAuthentication (==11.1)", "pyobjc-framework-LocalAuthenticationEmbeddedUI (==11.1)", "pyobjc-framework-MLCompute (==11.1)", "pyobjc-framework-MailKit (==11.1)", "pyobjc-framework-MapKit (==11.1)", "pyobjc-framework-MediaAccessibility (==11.1)", "pyobjc-framework-MediaExtension (==11.1)", "pyobjc-framework-MediaLibrary (==11.1)", "pyobjc-framework-MediaPlayer (==11.1)", "pyobjc-framework-MediaToolbox (==11.1)", "pyobjc-framework-Metal (==11.1)", "pyobjc-framework-MetalFX (==11.1)", "pyobjc-framework-MetalKit (==11.1)", "pyobjc-framework-MetalPerformanceShaders (==11.1)", "pyobjc-framework-MetalPerformanceShadersGraph (==11.1)", "pyobjc-framework-MetricKit (==11.1)", "pyobjc-framework-ModelIO (==11.1)", "pyobjc-framework-MultipeerConnectivity (==11.1)", "pyobjc-framework-NaturalLanguage (==11.1)", "pyobjc-framework-NetFS (==11.1)", "pyobjc-framework-Network (==11.1)", "pyobjc-framework-NetworkExtension (==11.1)", "pyobjc-framework-NotificationCenter (==11.1)", "pyobjc-framework-OSAKit (==11.1)", "pyobjc-framework-OSLog (==11.1)", "pyobjc-framework-OpenDirectory (==11.1)", "pyobjc-framework-PHASE (==11.1)", "pyobjc-framework-PassKit (==11.1)", "pyobjc-framework-PencilKit (==11.1)", "pyobjc-framework-Photos (==11.1)", "pyobjc-framework-PhotosUI (==11.1)", "pyobjc-framework-PreferencePanes (==11.1)", "pyobjc-framework-PubSub (==11.1)", "pyobjc-framework-PushKit (==11.1)", "pyobjc-framework-Quartz (==11.1)", "pyobjc-framework-QuickLookThumbnailing (==11.1)", "pyobjc-framework-ReplayKit (==11.1)", "pyobjc-framework-SafariServices (==11.1)", "pyobjc-framework-SafetyKit (==11.1)", "pyobjc-framework-SceneKit (==11.1)", "pyobjc-framework-ScreenCaptureKit (==11.1)", "pyobjc-framework-ScreenSaver (==11.1)", "pyobjc-framework-ScreenTime (==11.1)", "pyobjc-framework-ScriptingBridge (==11.1)", "pyobjc-framework-SearchKit (==11.1)", "pyobjc-framework-Security (==11.1)", "pyobjc-framework-SecurityFoundation (==11.1)", "pyobjc-framework-SecurityInterface (==11.1)", "pyobjc-framework-SecurityUI (==11.1)", "pyobjc-framework-SensitiveContentAnalysis (==11.1)", "pyobjc-framework-ServiceManagement (==11.1)", "pyobjc-framework-SharedWithYou (==11.1)", "pyobjc-framework-SharedWithYouCore (==11.1)", "pyobjc-framework-ShazamKit (==11.1)", "pyobjc-framework-Social (==11.1)", "pyobjc-framework-SoundAnalysis (==11.1)", "pyobjc-framework-Speech (==11.1)", "pyobjc-framework-SpriteKit (==11.1)", "pyobjc-framework-StoreKit (==11.1)", "pyobjc-framework-Symbols (==11.1)", "pyobjc-framework-SyncServices (==11.1)", "pyobjc-framework-SystemConfiguration (==11.1)", "pyobjc-framework-SystemExtensions (==11.1)", "pyobjc-framework-ThreadNetwork (==11.1)", "pyobjc-framework-UniformTypeIdentifiers (==11.1)", "pyobjc-framework-UserNotifications (==11.1)", "pyobjc-framework-UserNotificationsUI (==11.1)", "pyobjc-framework-VideoSubscriberAccount (==11.1)", "pyobjc-framework-VideoToolbox (==11.1)", "pyobjc-framework-Virtualization (==11.1)", "pyobjc-framework-Vision (==11.1)", "pyobjc-framework-WebKit (==11.1)", "pyobjc-framework-iTunesLibrary (==11.1)", "pyobjc-framework-libdispatch (==11.1)", "pyobjc-framework-libxpc (==11.1)"]
+
+[[package]]
+name = "pyobjc-core"
+version = "11.1"
+description = "Python<->ObjC Interoperability Module"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_core-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4c7536f3e94de0a3eae6bb382d75f1219280aa867cdf37beef39d9e7d580173c"},
+    {file = "pyobjc_core-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ec36680b5c14e2f73d432b03ba7c1457dc6ca70fa59fd7daea1073f2b4157d33"},
+    {file = "pyobjc_core-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:765b97dea6b87ec4612b3212258024d8496ea23517c95a1c5f0735f96b7fd529"},
+    {file = "pyobjc_core-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:18986f83998fbd5d3f56d8a8428b2f3e0754fd15cef3ef786ca0d29619024f2c"},
+    {file = "pyobjc_core-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8849e78cfe6595c4911fbba29683decfb0bf57a350aed8a43316976ba6f659d2"},
+    {file = "pyobjc_core-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8cb9ed17a8d84a312a6e8b665dd22393d48336ea1d8277e7ad20c19a38edf731"},
+    {file = "pyobjc_core-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:f2455683e807f8541f0d83fbba0f5d9a46128ab0d5cc83ea208f0bec759b7f96"},
+    {file = "pyobjc_core-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4a99e6558b48b8e47c092051e7b3be05df1c8d0617b62f6fa6a316c01902d157"},
+    {file = "pyobjc_core-11.1.tar.gz", hash = "sha256:b63d4d90c5df7e762f34739b39cc55bc63dbcf9fb2fb3f2671e528488c7a87fe"},
+]
+
+[[package]]
+name = "pyobjc-framework-accessibility"
+version = "11.1"
+description = "Wrappers for the framework Accessibility on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_accessibility-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8bbe921650607461fcaba6cfb921e8cb0d301e870553fb5353d7f1787a355696"},
+    {file = "pyobjc_framework_accessibility-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:332263153d829b946b311ddc8b9a4402b52d40a572b44c69c3242451ced1b008"},
+    {file = "pyobjc_framework_accessibility-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a049b63b32514da68aaaeef0d6c00a125e0618e4042aa6dbe3867b74fb2a8b2b"},
+    {file = "pyobjc_framework_accessibility-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd5a03b731d1a2bbb2bf706b58889a5e82df82ac69210ec3245c7dc69e42a63a"},
+    {file = "pyobjc_framework_accessibility-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3496c55569a421ef3c98ea66fc0ebaf68c686ede5b26db0fdcb0b0ad4191a20b"},
+    {file = "pyobjc_framework_accessibility-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7c4124981a5d84b71464babb4babfbeb5bfab145bc75b6f3577bd046a9579226"},
+    {file = "pyobjc_framework_accessibility-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea98239e339136e3d20d753afe7908006cf29567ba39b8e83ceda7c221e6aad1"},
+    {file = "pyobjc_framework_accessibility-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3b90638d583d8dd884aa7fca45e284d4a76e62d695f44f08102c01b19155a613"},
+    {file = "pyobjc_framework_accessibility-11.1.tar.gz", hash = "sha256:c0fa5f1e00906ec002f582c7d3d80463a46d19f672bf5ec51144f819eeb40656"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-accounts"
+version = "11.1"
+description = "Wrappers for the framework Accounts on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_accounts-11.1-py2.py3-none-any.whl", hash = "sha256:9c3fe342be7b8e73cba735e5a38affbe349cf8bc19091aa4fd788eabf2074b72"},
+    {file = "pyobjc_framework_accounts-11.1.tar.gz", hash = "sha256:384fec156e13ff75253bb094339013f4013464f6dfd47e2f7de3e2ae7441c030"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-addressbook"
+version = "11.1"
+description = "Wrappers for the framework AddressBook on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_addressbook-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:013db030aebe7c09752492ed8f9b12ff41b1264ed119e9858241d57276961e75"},
+    {file = "pyobjc_framework_addressbook-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d1d69330b5a87a29d26feea95dcf40681fd00ba3b40ac89579072ce536b6b647"},
+    {file = "pyobjc_framework_addressbook-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb3d0a710f8342a0c63a8e4caf64a044b4d7e42d6d242c8e1b54470238b938cb"},
+    {file = "pyobjc_framework_addressbook-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:411adf4874cc4343f2928a26fe4cb3673d2f5f73365b45cd3650aa7304a45e24"},
+    {file = "pyobjc_framework_addressbook-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6735f297f0e5fd109fa77ca90cace57eb2e10eb65e3c15ccd249df2228030d3b"},
+    {file = "pyobjc_framework_addressbook-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:e4004bdf134a069c58d91b231cbeb9e0adad26a73d2689015baaf6a98c411c54"},
+    {file = "pyobjc_framework_addressbook-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:6bc42832e85f418a9f978b7e001e219faf52cbb279a0df185115cd4292c381cb"},
+    {file = "pyobjc_framework_addressbook-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8f90a3e3a66deb737977586782b173d4e246e74afb7c0ff3af08920d57498256"},
+    {file = "pyobjc_framework_addressbook-11.1.tar.gz", hash = "sha256:ce2db3be4a3128bf79d5c41319a6d16b73754785ce75ac694d0d658c690922fc"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-adservices"
+version = "11.1"
+description = "Wrappers for the framework AdServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_adservices-11.1-py2.py3-none-any.whl", hash = "sha256:1744f59a75b2375e139c39f3e85658e62cd10cc0f12b158a80421f18734e9ffc"},
+    {file = "pyobjc_framework_adservices-11.1.tar.gz", hash = "sha256:44c72f8163705c9aa41baca938fdb17dde257639e5797e6a5c3a2b2d8afdade9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-adsupport"
+version = "11.1"
+description = "Wrappers for the framework AdSupport on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"18.0\""
+files = [
+    {file = "pyobjc_framework_adsupport-11.1-py2.py3-none-any.whl", hash = "sha256:c3e009612778948910d3a7135b9d77b9b7c06aab29d40957770834c083acf825"},
+    {file = "pyobjc_framework_adsupport-11.1.tar.gz", hash = "sha256:78b9667c275785df96219d205bd4309731869c3298d0931e32aed83bede29096"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-applescriptkit"
+version = "11.1"
+description = "Wrappers for the framework AppleScriptKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_applescriptkit-11.1-py2.py3-none-any.whl", hash = "sha256:e22cbc9d1a25a4a713f21aa94dd017c311186b02062fc7ffbde3009495fb0067"},
+    {file = "pyobjc_framework_applescriptkit-11.1.tar.gz", hash = "sha256:477707352eaa6cc4a5f8c593759dc3227a19d5958481b1482f0d59394a4601c3"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-applescriptobjc"
+version = "11.1"
+description = "Wrappers for the framework AppleScriptObjC on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_applescriptobjc-11.1-py2.py3-none-any.whl", hash = "sha256:ac22526fd1f0a3b07ac1d77f90046b77f10ec9549182114f2428ee1e96d3de2b"},
+    {file = "pyobjc_framework_applescriptobjc-11.1.tar.gz", hash = "sha256:c8a0ec975b64411a4f16a1280c5ea8dbe949fd361e723edd343102f0f95aba6e"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "11.1"
+description = "Wrappers for the framework ApplicationServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_applicationservices-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:89aa713f16f1de66efd82f3be77c632ad1068e51e0ef0c2b0237ac7c7f580814"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cf45d15eddae36dec2330a9992fc852476b61c8f529874b9ec2805c768a75482"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f4a85ccd78bab84f7f05ac65ff9be117839dfc09d48c39edd65c617ed73eb01c"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:385a89f4d0838c97a331e247519d9e9745aa3f7427169d18570e3c664076a63c"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f480fab20f3005e559c9d06c9a3874a1f1c60dde52c6d28a53ab59b45e79d55f"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:e8dee91c6a14fd042f98819dc0ac4a182e0e816282565534032f0e544bfab143"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a0ce40a57a9b993793b6f72c4fd93f80618ef54a69d76a1da97b8360a2f3ffc5"},
+    {file = "pyobjc_framework_applicationservices-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ba671fc6b695de69b2ed5e350b09cc1806f39352e8ad07635c94ef17730f6fe0"},
+    {file = "pyobjc_framework_applicationservices-11.1.tar.gz", hash = "sha256:03fcd8c0c600db98fa8b85eb7b3bc31491701720c795e3f762b54e865138bbaf"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreText = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-apptrackingtransparency"
+version = "11.1"
+description = "Wrappers for the framework AppTrackingTransparency on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_apptrackingtransparency-11.1-py2.py3-none-any.whl", hash = "sha256:e25c3eae25d24ee8b523b7ecc4d2b07af37c7733444b80c4964071dea7b0cb19"},
+    {file = "pyobjc_framework_apptrackingtransparency-11.1.tar.gz", hash = "sha256:796cc5f83346c10973806cfb535d4200b894a5d2626ff2eeb1972d594d14fed4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-audiovideobridging"
+version = "11.1"
+description = "Wrappers for the framework AudioVideoBridging on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:dd88f7083cc7858c21bfc151a9745e6c24d4f4fa1c3ad5a50673f34c42e17111"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:db570433910d1df49cc45d25f7a966227033c794fb41133d59212689b86b1ac6"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:591e80ff6973ea51a12f7c1a2e3fd59496633a51d5a1bf73f4fb989a43e23681"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30a12be3784f41e1c6b5ef532c08e73bae7071d9a036b26b1e36b919ee5b6f57"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3bef4383dc9233dbd9efc3817ce9c8fe8670c61d21a94de3c149e7f460245792"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:6159b94448af08c9b119eb6ecf3fdbc2b3348ad66fb99586f991939779e412ec"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e466561bd9eb77be050aabead6ad7313a480d05389d9892e1db2cbc06ce1f475"},
+    {file = "pyobjc_framework_audiovideobridging-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0699a7052672e9bb5c77054c59aff50183293e5944e4ac416d258f262ff25650"},
+    {file = "pyobjc_framework_audiovideobridging-11.1.tar.gz", hash = "sha256:12756b3aa35083b8ad5c9139b6a0e2f4792e217096b5bf6b702d499038203991"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-authenticationservices"
+version = "11.1"
+description = "Wrappers for the framework AuthenticationServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_authenticationservices-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4454c2f69c04fc31c0ec0924ccb3aa9bfe8a11d5632d83172904b5b4cc34d8b5"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3987b7fc9493c2ba77b773df99f6631bff1ee9b957d99e34afa6b4e1c9d48bfb"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6655dd53d9135ef85265a4297da5e7459ed7836973f2796027fdfbfd7f08e433"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:364035d265129192e6906f7a94cbdf714d737b6b9f20e56bfe74d0007c8761b1"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e92bf7e829229fbecba4f7f649d3ae38760cf25aa9e909c0e737b1945f36b62d"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60bf585e561d885cc88a21713ef2db259baf6434ce7116f82265a0c727f29dba"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:f19ea757ecfda6ac929559c779c3afb001855dd5e41e4acc4c42343c7d912da6"},
+    {file = "pyobjc_framework_authenticationservices-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:972fd38fca75ffd4314169e8cc6eeb6784fc2ca080a399b8a6f74b8849548729"},
+    {file = "pyobjc_framework_authenticationservices-11.1.tar.gz", hash = "sha256:8fd801cdb53d426b4e678b0a8529c005d0c44f5a17ccd7052a7c3a1a87caed6a"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-automaticassessmentconfiguration"
+version = "11.1"
+description = "Wrappers for the framework AutomaticAssessmentConfiguration on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a88e75b600c570939190795ead28e097c62aa040467088352c550df52d96e8d4"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:50cc5466bec1f58f79921d49544b525b56897cb985dfcfabf825ee231c27bcfc"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:55d1684dd676730fb1afbc7c67e0669e3a7159f18c126fea7453fe6182c098f9"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fbcbe406c2a02d632885f6b23285c259b715f019b938d666cc554a66ecf5f9c3"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e5fa297c7d4db225f75e5d11121fa68e0956c104e14b24250a52157a180e5f6c"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:4b11c33fb6f6092b9e1fb63747f2402f516b7ff0f815be4ece4625f2a2ec954f"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:378d233879bb011ed9d0bcf1b0e3c048fb756023d0f6819e997f62acc2c32bc3"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6d2a21425908f34d30840600e810883b0616e21810afcc6ab122bec6b95ef300"},
+    {file = "pyobjc_framework_automaticassessmentconfiguration-11.1.tar.gz", hash = "sha256:70eadbf8600101901a56fcd7014d8941604e14f3b3728bc4fb0178a9a9420032"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-automator"
+version = "11.1"
+description = "Wrappers for the framework Automator on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_automator-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:569f9fedcd107721c59eccce89c5befe429baace59616f9f1ceeb9689a65f273"},
+    {file = "pyobjc_framework_automator-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bf675a19edd97de9c19dcfd0fea9af9ebbd3409786c162670d1d71cb2738e341"},
+    {file = "pyobjc_framework_automator-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:af5941f8d90167244209b352512b7779e5590d17dc1e703e087a6cfe79ee3d64"},
+    {file = "pyobjc_framework_automator-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3458f836671ea922ad0771f617c927e9c52841c0a6e71b4a5a9dbb438736c207"},
+    {file = "pyobjc_framework_automator-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:203b888152a78b39a8c67be663ff78a749ebff208ce993b4419fc4409faa1fda"},
+    {file = "pyobjc_framework_automator-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:651760236cb2d2481faa5afb66da97054850d34fdbebc5e4ee2f83a683a8be10"},
+    {file = "pyobjc_framework_automator-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:112815d2e1b6002b4f9bc644bdae6b02257d249145c79346d7b8bb11e6f76b03"},
+    {file = "pyobjc_framework_automator-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:31f4ae025179afa2fc89731904607966f4a37cda4aa9f684e5646a6b25915466"},
+    {file = "pyobjc_framework_automator-11.1.tar.gz", hash = "sha256:9b46c55a4f9ae2b3c39ff560f42ced66bdd18c093188f0b5fc4060ad911838e4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "11.1"
+description = "Wrappers for the framework AVFoundation on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"11.0\""
+files = [
+    {file = "pyobjc_framework_avfoundation-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09542590d1f3aa96d4d1a37712b98fd9657e250d9ea06ecdf2a8a59c837a2cb6"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8a0ccbdba46b69dec1d12eea52eef56fcd63c492f73e41011bb72508b2aa2d0e"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:94f065db4e87b1baebb5cf9f464cf9d82c5f903fff192001ebc974d9e3132c7e"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e204d155a09c186601490e4402dcffb2845a5831079e389b47bd6a341fe5ee63"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dd3965aad0b236b8ac12f216d688c1a22b963f63e7e4fdb7107dd6790e80ee12"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:1ab2108b652496b13b9758c295f0f6de53b6d12125cf574ddae84ce28044bce1"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:5dd6ac6a57f86b7ed5ac0a965ce54328f6ce77816b4a1fbf0d85c06fb251867a"},
+    {file = "pyobjc_framework_avfoundation-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:54e1a65ad908d2dc69ea9d644f02893e397f750194c457479caa9487acf08fbb"},
+    {file = "pyobjc_framework_avfoundation-11.1.tar.gz", hash = "sha256:6663056cc6ca49af8de6d36a7fff498f51e1a9a7f1bde7afba718a8ceaaa7377"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreAudio = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-avkit"
+version = "11.1"
+description = "Wrappers for the framework AVKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_avkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e211c8dce60b7dd7ad2994ad404041a50e183a039b253f891dbb8cab48f5e687"},
+    {file = "pyobjc_framework_avkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:88f70e2a399e43ce7bc3124b3b35d65537daddb358ea542fbb0146fa6406be8a"},
+    {file = "pyobjc_framework_avkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ef9cd9fe37c6199bfde7ee5cd6e76ede23a6797932882785c53ef3070e209afb"},
+    {file = "pyobjc_framework_avkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c5810b349745078ef8b4a562e85afe40de3245127f633d8cabe98aeca765c7fc"},
+    {file = "pyobjc_framework_avkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:023b1cdb78c3aa5873d8abe69697396872b47278208991ec5e5aea4464309b01"},
+    {file = "pyobjc_framework_avkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a6b418603fc270a8e63c2a5efffa753704fd14bf8bca0657901c49a7cc9b22b5"},
+    {file = "pyobjc_framework_avkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3a5f22bc4f4b0b82c8039d37996882bf4a38f509963d1afa3275a45ddd4a0b00"},
+    {file = "pyobjc_framework_avkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:047cca5eb98002f8178b9dfe0671b6dbad504117972b120e5d6d30038eccbf4e"},
+    {file = "pyobjc_framework_avkit-11.1.tar.gz", hash = "sha256:d948204a7b94e0e878b19a909f9b33342e19d9ea519571d66a21fce8f72e3263"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-avrouting"
+version = "11.1"
+description = "Wrappers for the framework AVRouting on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_avrouting-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:230daf3e5135f6ad0ab0acd6cf3a01a4b0d6b07eb82d63d6e8037479b6cac4ea"},
+    {file = "pyobjc_framework_avrouting-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:45cbabbf69764b2467d78adb8f3b7f209d1a8ee690e19f9a32d05c62a9c3a131"},
+    {file = "pyobjc_framework_avrouting-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dc309e175abf3961f933f8b341c0504b17f4717931242ebb121a83256b8b5c13"},
+    {file = "pyobjc_framework_avrouting-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f52f9d62a3c8485b5687187ea58d905d7edccac9941c444b4add8129841cd031"},
+    {file = "pyobjc_framework_avrouting-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6a7b335161d327792f42054acb3ff415f7778e1492582df8e91b8609b4b02244"},
+    {file = "pyobjc_framework_avrouting-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:120c9d65d4f9047b9921f8dced0b4f26d799156bc08ff7e3974217cd036b1bfc"},
+    {file = "pyobjc_framework_avrouting-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:9aa9b0a7ae7ee5874e7d92bebefca4525d5cf1f0aa1f50e78e558984a39cad2e"},
+    {file = "pyobjc_framework_avrouting-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:815cdda6f6700291fa600ca8194e945c0bb13035f506f3bda94e1657af16b6d9"},
+    {file = "pyobjc_framework_avrouting-11.1.tar.gz", hash = "sha256:7db1291d9f53cc58d34b2a826feb721a85f50ceb5e71952e8762baacd3db3fc0"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-backgroundassets"
+version = "11.1"
+description = "Wrappers for the framework BackgroundAssets on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_backgroundassets-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:30b4fe4b711e1dacf48074f10b8cad680b4e2c422652ae3c32b1f89bb5bac54e"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bd371ce08d1b79f540d5994139898097b83b1d4e4471c264892433d448b24de0"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:13bf451c59b409b6ce1ac0e717a970a1b03bca7a944a7f19219da0d46ab7c561"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:708466d847a479e1798f31c59fbc5307473d03fa1083f40cfcaa18fd31819c40"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2484a2f9c87e8cae2fc375a39d68ea7ff02e4fb786e4afe88237c51fd5e78ec9"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a72536ed18cf2462085bbb2184d0a3eecf9b97669c0ef4db45418555a609b534"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a4db45048d1021900be5b03136b927773820bcbb40d623aeac54712e1c86d6f6"},
+    {file = "pyobjc_framework_backgroundassets-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:aab88a14ce12c80718c894c1cc1b6ee64611a2047a7a990ad01fb29f462ad121"},
+    {file = "pyobjc_framework_backgroundassets-11.1.tar.gz", hash = "sha256:2e14b50539d96d5fca70c49f21b69fdbad81a22549e3630f5e4f20d5c0204fc2"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-browserenginekit"
+version = "11.1"
+description = "Wrappers for the framework BrowserEngineKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"23.4\""
+files = [
+    {file = "pyobjc_framework_browserenginekit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cbfb0183378a0dc836bcdf3798c358c6d217aeaac726e1d44be7cc123994c0fa"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:29b5f5949170af0235485e79aa465a7af2b2e0913d0c2c9ab1ac033224a90edb"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9b815b167533015d62832b956e9cfb962bd2026f5a4ccd66718cf3bb2e15ab27"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dfe469f8eb1313ea0cbe0616cd3bbc56f62bdd8a683c959819ef01d7e9ac0de7"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f3332ffa9ae74cc6633fd17f6d998ac77b8939abbe9ecf95ae56df200ee93853"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c3195c4fb3b84150fac6dd18ce318eaae17f246f98678825397ed80d6da3c371"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:1f4cce594a94d0bc0a020122153f8149c16578fa4761b0e27d868c013f76214c"},
+    {file = "pyobjc_framework_browserenginekit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:15d1668b97346dfa9a8215e3f8a2aa09cab01526825983cd6045df50f553ec6b"},
+    {file = "pyobjc_framework_browserenginekit-11.1.tar.gz", hash = "sha256:918440cefb10480024f645169de3733e30ede65e41267fa12c7b90c264a0a479"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreAudio = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-businesschat"
+version = "11.1"
+description = "Wrappers for the framework BusinessChat on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"18.0\""
+files = [
+    {file = "pyobjc_framework_businesschat-11.1-py2.py3-none-any.whl", hash = "sha256:7fdc1219b988ce3ae896bffd01f547c06cec3b4e4b2d0aa04d251444d7f1c2db"},
+    {file = "pyobjc_framework_businesschat-11.1.tar.gz", hash = "sha256:69589d2f0cb4e7892e5ecc6aed79b1abd1ec55c099a7faacae6a326bc921259d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-calendarstore"
+version = "11.1"
+description = "Wrappers for the framework CalendarStore on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"9.0\""
+files = [
+    {file = "pyobjc_framework_calendarstore-11.1-py2.py3-none-any.whl", hash = "sha256:bf066e17392c978becf17a61863eb81727bf593a2bfdab261177126072557e24"},
+    {file = "pyobjc_framework_calendarstore-11.1.tar.gz", hash = "sha256:858ee00e6a380d9c086c2d7db82c116a6c406234038e0ec8fc2ad02e385dc437"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-callkit"
+version = "11.1"
+description = "Wrappers for the framework CallKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_callkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:afa1520c462b571458d0d6139681820b4abd41d7dbd7d4892fb2617dd9037846"},
+    {file = "pyobjc_framework_callkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1db8b74abd6489d73c8619972730bea87a7d1f55d47649150fc1a30fdc6840fb"},
+    {file = "pyobjc_framework_callkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:554e09ca3dab44d93a89927d9e300f004d2ef0db020b10425a4622b432e7b684"},
+    {file = "pyobjc_framework_callkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fc5e638ddbc9dd3e9993205d2b077f5db41b6cd4e97b9c5592b7249575f23f04"},
+    {file = "pyobjc_framework_callkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bc1d2349dab93f7a0d298b01893828d7f46aded9122a341469b835d977a0646d"},
+    {file = "pyobjc_framework_callkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:b69b4262897f2701348ea0da36afe32d60f84e2a036baf13e258a97875b25a6c"},
+    {file = "pyobjc_framework_callkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:8266ee797fdabb657f7cb4fa808404fc33fcf3f31d4bcab1ab3c53d272e1ff83"},
+    {file = "pyobjc_framework_callkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:69928680d7fe500f2240be78e51e3581a775e028b538b74fc2e8563932656687"},
+    {file = "pyobjc_framework_callkit-11.1.tar.gz", hash = "sha256:b84d5ea38dff0cbe0754f5f9f6f33c742e216f12e7166179a8ec2cf4b0bfca94"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-carbon"
+version = "11.1"
+description = "Wrappers for the framework Carbon on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_carbon-11.1-py2.py3-none-any.whl", hash = "sha256:1bf66853e939315ad7ee968170b16dd12cb838c42b80dfcd5354687760998825"},
+    {file = "pyobjc_framework_carbon-11.1.tar.gz", hash = "sha256:047f098535479efa3ab89da1ebdf3cf9ec0b439a33a4f32806193886e9fcea71"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-cfnetwork"
+version = "11.1"
+description = "Wrappers for the framework CFNetwork on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_cfnetwork-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8cf313e3ac580ee0d3c2345771e6cafc4ba95a10418e3e535feeda4c62b68295"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d7a24746d0754b3a0042def2cd64aa205e5614f12ea0de9461c8e26d97633c72"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:70beb8095df76e0e8eb7ab218be1e69ae180e01a4d77f7cad73c97b4eb7a296a"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5dd866fcbe6870931373636d19144544344f0f89685f6720e4a45453957702dd"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:62ccc6dcaaa5877534d21f93a15861a3d8af95888123d659f9ff5383d1a2a1f4"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:4b998daa3e6ce253c48455365f004647b3b1da2f313fbc8a5a607e460b4d5567"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:2e9a4ce6b416bff881df499d9060c1096220ef8c20e519108a7b91692d1fd1d7"},
+    {file = "pyobjc_framework_cfnetwork-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:67390b4866cd1671ebc6a45fb38df28158b28ce1ce927d43cda3d2f4de6ef8d6"},
+    {file = "pyobjc_framework_cfnetwork-11.1.tar.gz", hash = "sha256:ad600163eeadb7bf71abc51a9b6f2b5462a018d3f9bb1510c5ce3fdf2f22959d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-cinematic"
+version = "11.1"
+description = "Wrappers for the framework Cinematic on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"23.0\""
+files = [
+    {file = "pyobjc_framework_cinematic-11.1-py2.py3-none-any.whl", hash = "sha256:b62c024c1a9c7890481bc2fdfaf0cd3c251a4a08357d57dc1795d98920fcdbd1"},
+    {file = "pyobjc_framework_cinematic-11.1.tar.gz", hash = "sha256:efde39a6a2379e1738dbc5434b2470cd187cf3114ffb81390b3b1abda470b382"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-AVFoundation = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+pyobjc-framework-Metal = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-classkit"
+version = "11.1"
+description = "Wrappers for the framework ClassKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_classkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1cb2a2b68fb4c773e9ff250f2ab87c41b7464778d4c7e0174600de3cf5f7b52e"},
+    {file = "pyobjc_framework_classkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:018da363d06f3615c07a8623cbdb024a31b1f8b96a933ff2656c0e903063842c"},
+    {file = "pyobjc_framework_classkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:161dcb9b718649e6331a5eab5a76c2b43a9b322b15b37b3f8f9c5faad12ee6d1"},
+    {file = "pyobjc_framework_classkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:08000deb43004d16fb39ccd83b3de30e1e3b72639a79d05206d7d5c15f005b3a"},
+    {file = "pyobjc_framework_classkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ef28d042964b0f757569e72df737bb049b531c33b7d06a705ce2dcfa4e6e45d8"},
+    {file = "pyobjc_framework_classkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:be279d91f10d68ad9a256e96d26d8975e35b9b1bb304c82491766d29ad252b0d"},
+    {file = "pyobjc_framework_classkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:9a1b9d31f9b23e05b92769bbdb4ef2167a59b3b24aefa6af86448f5087a2e105"},
+    {file = "pyobjc_framework_classkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b582955866fa1d272cadbaac0f5ce01149b40b3bc529dfa7416fd01265a9afa4"},
+    {file = "pyobjc_framework_classkit-11.1.tar.gz", hash = "sha256:ee1e26395eb00b3ed5442e3234cdbfe925d2413185af38eca0477d7166651df4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-cloudkit"
+version = "11.1"
+description = "Wrappers for the framework CloudKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_cloudkit-11.1-py2.py3-none-any.whl", hash = "sha256:c583e40c710cf85ebe34173d1d2995e832a20127edc8899b2f35b13f98498af1"},
+    {file = "pyobjc_framework_cloudkit-11.1.tar.gz", hash = "sha256:40d2dc4bf28c5be9b836b01e4d267a15d847d756c2a65530e1fcd79b2825e86d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Accounts = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreData = ">=11.1"
+pyobjc-framework-CoreLocation = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "11.1"
+description = "Wrappers for the Cocoa frameworks on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_cocoa-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b27a5bdb3ab6cdeb998443ff3fce194ffae5f518c6a079b832dbafc4426937f9"},
+    {file = "pyobjc_framework_cocoa-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7b9a9b8ba07f5bf84866399e3de2aa311ed1c34d5d2788a995bdbe82cc36cfa0"},
+    {file = "pyobjc_framework_cocoa-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806de56f06dfba8f301a244cce289d54877c36b4b19818e3b53150eb7c2424d0"},
+    {file = "pyobjc_framework_cocoa-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54e93e1d9b0fc41c032582a6f0834befe1d418d73893968f3f450281b11603da"},
+    {file = "pyobjc_framework_cocoa-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fd5245ee1997d93e78b72703be1289d75d88ff6490af94462b564892e9266350"},
+    {file = "pyobjc_framework_cocoa-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:aede53a1afc5433e1e7d66568cc52acceeb171b0a6005407a42e8e82580b4fc0"},
+    {file = "pyobjc_framework_cocoa-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:1b5de4e1757bb65689d6dc1f8d8717de9ec8587eb0c4831c134f13aba29f9b71"},
+    {file = "pyobjc_framework_cocoa-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bbee71eeb93b1b31ffbac8560b59a0524a8a4b90846a260d2c4f2188f3d4c721"},
+    {file = "pyobjc_framework_cocoa-11.1.tar.gz", hash = "sha256:87df76b9b73e7ca699a828ff112564b59251bb9bbe72e610e670a4dc9940d038"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-collaboration"
+version = "11.1"
+description = "Wrappers for the framework Collaboration on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"9.0\""
+files = [
+    {file = "pyobjc_framework_collaboration-11.1-py2.py3-none-any.whl", hash = "sha256:3629ea5b56c513fb330d43952afabb2df2a2ac2f9048b8ec6e8ab4486191390a"},
+    {file = "pyobjc_framework_collaboration-11.1.tar.gz", hash = "sha256:4564e3931bfc51773623d4f57f2431b58a39b75cb964ae5c48d27ee4dde2f4ea"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-colorsync"
+version = "11.1"
+description = "Wrappers for the framework ColorSync on Mac OS X"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"17.0\""
+files = [
+    {file = "pyobjc_framework_colorsync-11.1-py2.py3-none-any.whl", hash = "sha256:d19d6da2c7175a3896a63c9b40a8ab98ade0779a5b40062789681501c33efd5c"},
+    {file = "pyobjc_framework_colorsync-11.1.tar.gz", hash = "sha256:7a346f71f34b2ccd1b020a34c219b85bf8b6f6e05283d503185aeb7767a269dd"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "11.1"
+description = "Wrappers for the framework Contacts on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_contacts-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:01a83ac9e03cab16ee7eb8755c87ce1790c8465487a07994da5569d843facc05"},
+    {file = "pyobjc_framework_contacts-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:68148653f27c1eaeff2ad4831b5e68393071a382aab773629cd047ce55556726"},
+    {file = "pyobjc_framework_contacts-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:576ee4aec05d755444bff10b45833f73083b5b3d1b2740e133b92111f7765e54"},
+    {file = "pyobjc_framework_contacts-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09b873d2bd739fea63d744430defb04ce4b44af064aaf0b6bf558eea23f82bd7"},
+    {file = "pyobjc_framework_contacts-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:23312bb4bfc5aafecdac84ca402189e312e754e9dc0586d8f282d225c3952c00"},
+    {file = "pyobjc_framework_contacts-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3409aba6e23cb179b3fe932c1a0a53d7b273ac8292d5adf1bf6849e925cc0955"},
+    {file = "pyobjc_framework_contacts-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:910f40a2e4d80a97f282bfdecba0f5ff95201b11844acd3f9cb9522db364ab57"},
+    {file = "pyobjc_framework_contacts-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:42d035887b2e4c52088ae09424aef13bde6658f6d3c39190d62030f9ab05d758"},
+    {file = "pyobjc_framework_contacts-11.1.tar.gz", hash = "sha256:752036e7d8952a4122296d7772f274170a5f35a53ee6454a27f3e1d9603222cc"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-contactsui"
+version = "11.1"
+description = "Wrappers for the framework ContactsUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_contactsui-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cf3468444ba88dd6814e02ffa624d13b7857a7baf042462452bb292337c013da"},
+    {file = "pyobjc_framework_contactsui-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1c0f03c71e63daf5dbf760bf0e45620618a6f1ea62f8c17e288463c1fd4d2685"},
+    {file = "pyobjc_framework_contactsui-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c34a6f27ef5aa4742cc44fd5b4d16fe1e1745ff839578b4c059faf2c58eee3ca"},
+    {file = "pyobjc_framework_contactsui-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f3b4f0225645a26ed9e6c008c2e8c217035b4a50fa9cd6623c628a11c37924d0"},
+    {file = "pyobjc_framework_contactsui-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:666586174b306b33b791d2edee021cd979a8c970d444f906ed294e27583a6b54"},
+    {file = "pyobjc_framework_contactsui-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7901eed3c669ad52cca86089c443fd30820b21586bf758e03fb83696f435ba87"},
+    {file = "pyobjc_framework_contactsui-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:8b03bd175095b4774c55bd5f38a01942e945b668bea15b9dc3b4f1a28b1a8696"},
+    {file = "pyobjc_framework_contactsui-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0d4fd93409c0773d0fe6670ebc1c1c27169ecae4004518c59c4c4cba098d7626"},
+    {file = "pyobjc_framework_contactsui-11.1.tar.gz", hash = "sha256:5bc29ea2b10a342018e1b96be6b140c10ebe3cfb6417278770feef5e88026a1f"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Contacts = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "11.1"
+description = "Wrappers for the framework CoreAudio on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coreaudio-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:551c8aac6fdfbd34c3e2d4ce90b36a411e81be20581b978fa4da1a495489792d"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:73a46f0db2fa8ca2e8c47c3ddcc2751e67a0f8600246a6718553b15ee0dbbdb6"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2538d1242dab4e27efb346eafbad50594e7e95597fa7220f0bab2099c825da55"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f73d996df1e721931d9f78050e1708735a173dbe3a76d9c71fb36e04f7208478"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:67dae111b78d91c26c753dbfbccc3ea5498cfda3dfe83c6f3778628b435e1e7b"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:9527a16a2b88b37bace578d499f21229f9a33b9afdcdd35d4f44374cb8eb9ab6"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:6ba8b67f185c0e3f26b17ae525cee3f411bc8d6e9c9a8bfd899a28f594623d2f"},
+    {file = "pyobjc_framework_coreaudio-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:65b9275cb00dfa75560cb20adcdc52025b875d8ed98b94c8c937f3526cfb0386"},
+    {file = "pyobjc_framework_coreaudio-11.1.tar.gz", hash = "sha256:b7b89540ae7efc6c1e3208ac838ef2acfc4d2c506dd629d91f6b3b3120e55c1b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coreaudiokit"
+version = "11.1"
+description = "Wrappers for the framework CoreAudioKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3be9e254d607324cfc059e3f11fe528fc95d59bb72e585d4bb4ecf92ef493000"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4743fbd210159cffffb0a7b8e06bf8b8527ba4bf01e76806fae2696fd6990e77"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:20440a2926b1d91da8efc8bc060e77c7a195cb0443dbf3770eaca9e597276748"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11d42770dfbc6a8af8d5fa39a4f700f0067d7e6c7ba9335e6624d89de3c599a9"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6fea7c7ea5305e8cbd75808ec4edcde8e2320137f227b3d771266dd9a71e1fa5"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a71447196a48869b551a2e3b6ba92f39241cb64d0257120505c62ddb611aef0f"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:8d012561eb95877f0214aa0cd13043b1a2693add4a9534d1e6fb82f6d7183c7c"},
+    {file = "pyobjc_framework_coreaudiokit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:be1053734771dfe0eafd2b944b899003957d75074efc8652c306dda0fdf9cd95"},
+    {file = "pyobjc_framework_coreaudiokit-11.1.tar.gz", hash = "sha256:0b461c3d6123fda4da6b6aaa022efc918c1de2e126a5cf07d2189d63fa54ba40"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreAudio = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "11.1"
+description = "Wrappers for the framework CoreBluetooth on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_corebluetooth-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ab509994503a5f0ec0f446a7ccc9f9a672d5a427d40dba4563dd00e8e17dfb06"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:433b8593eb1ea8b6262b243ec903e1de4434b768ce103ebe15aac249b890cc2a"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36bef95a822c68b72f505cf909913affd61a15b56eeaeafea7302d35a82f4f05"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:992404b03033ecf637e9174caed70cb22fd1be2a98c16faa699217678e62a5c7"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ebb8648f5e33d98446eb1d6c4654ba4fcc15d62bfcb47fa3bbd5596f6ecdb37c"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:e84cbf52006a93d937b90421ada0bc4a146d6d348eb40ae10d5bd2256cc92206"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:4da1106265d7efd3f726bacdf13ba9528cc380fb534b5af38b22a397e6908291"},
+    {file = "pyobjc_framework_corebluetooth-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e9fa3781fea20a31b3bb809deaeeab3bdc7b86602a1fd829f0e86db11d7aa577"},
+    {file = "pyobjc_framework_corebluetooth-11.1.tar.gz", hash = "sha256:1deba46e3fcaf5e1c314f4bbafb77d9fe49ec248c493ad00d8aff2df212d6190"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coredata"
+version = "11.1"
+description = "Wrappers for the framework CoreData on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coredata-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ceeba4f9d156610f17e643fc8bdf40bd785bda92fad6f4cbf0954894aa4db165"},
+    {file = "pyobjc_framework_coredata-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c66ae04cc658eafdfb987f9705e21f9782edee6773a8adb6bfa190500e4e7e29"},
+    {file = "pyobjc_framework_coredata-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c9b2374784e67694a18fc8c120a12f11b355a20b643c01f23ae2ce87330a75e0"},
+    {file = "pyobjc_framework_coredata-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:007160eb10bb8c789076f231e3d625d8875ca42eb5a806fdab5d0277c48866f8"},
+    {file = "pyobjc_framework_coredata-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:699ad568f98f58e88e642159c91ffff0c68ce3d1ec798e4af8333b27431fd058"},
+    {file = "pyobjc_framework_coredata-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d84afaccbb4f18dbda4c557cd059b7adc2116436a065353e25e7cbc840d9f8b4"},
+    {file = "pyobjc_framework_coredata-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:89dde863eff01ed6b5f8d88c764a08b154ef37078397c98c5f403e8798723b9d"},
+    {file = "pyobjc_framework_coredata-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2c361a5a09f6623a0276ad1c19c2952582850b014493c24ed03a32124892e573"},
+    {file = "pyobjc_framework_coredata-11.1.tar.gz", hash = "sha256:fe9fd985f8e06c70c0fb1e6bbea5b731461f9e76f8f8d8e89c7c72667cdc6adf"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-corehaptics"
+version = "11.1"
+description = "Wrappers for the framework CoreHaptics on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_corehaptics-11.1-py2.py3-none-any.whl", hash = "sha256:8f8c47ccca5052d07f95d2f35e6e399c5ac1f2072ba9d9eaae902edf4e3a7af4"},
+    {file = "pyobjc_framework_corehaptics-11.1.tar.gz", hash = "sha256:e5da3a97ed6aca9b7268c8c5196c0a339773a50baa72d1502d3435dc1a2a80f1"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-corelocation"
+version = "11.1"
+description = "Wrappers for the framework CoreLocation on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_corelocation-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:90d7811a2b730f604b0a2ac54c3c822e6e048287e2cd1db80fd3bd1caac6c1c0"},
+    {file = "pyobjc_framework_corelocation-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ea261e7d87c6f62f1b03c252c273ea7fd6f314e3e73c69c6fb3fe807bf183462"},
+    {file = "pyobjc_framework_corelocation-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:562e31124f80207becfd8df01868f73fa5aa70169cc4460e1209fb16916e4fb4"},
+    {file = "pyobjc_framework_corelocation-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0f8182835429118a55ed65963c80f5b2892d190747b986e8395b1cd99f41a1d0"},
+    {file = "pyobjc_framework_corelocation-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bc3f27802415aa62330a2d2507adc3a9b98a89d6de7d1033ebe6b8c461610831"},
+    {file = "pyobjc_framework_corelocation-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:17ce2530bd5a0dca9059eb11bc647d920490bcdd35b5cac1e160f51f0297bdc8"},
+    {file = "pyobjc_framework_corelocation-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a384d9fcba2c041d8f8115b51a07ef11c391bc30f72560aaea8b94db6b3b225c"},
+    {file = "pyobjc_framework_corelocation-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:149d69ee758ac62be8c44fb0ae25ca48c53ec457abcd0e054a4992f1fe98c771"},
+    {file = "pyobjc_framework_corelocation-11.1.tar.gz", hash = "sha256:46a67b99925ee3d53914331759c6ee110b31bb790b74b05915acfca41074c206"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "11.1"
+description = "Wrappers for the framework CoreMedia on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"11.0\""
+files = [
+    {file = "pyobjc_framework_coremedia-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91231957d25b6d191983166cf218189b5a01e267dadde35eb3a4c359dc473ccb"},
+    {file = "pyobjc_framework_coremedia-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aacf47006e1c6bf6124fb2b5016a8d5fd5cf504b6b488f9eba4e389ab0f0a051"},
+    {file = "pyobjc_framework_coremedia-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ea5055298af91e463ffa7977d573530f9bada57b8f2968dcc76a75e339b9a598"},
+    {file = "pyobjc_framework_coremedia-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7ecdb64c743ffe9fd3949c7cc9109891b9f399a0852717fcb969d33c4e7ba527"},
+    {file = "pyobjc_framework_coremedia-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:969ce357c616f6835f47e27d1e73964374cdb671476571dfd358894a8ced06f2"},
+    {file = "pyobjc_framework_coremedia-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bf1da05c297776c297ab3489ebf18d954efdff530acbdd6e70c32be811e20ec6"},
+    {file = "pyobjc_framework_coremedia-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:aa942d9ad0cf5bc4d3ede8779c3fac2f04cf3857687f2fb8505bae3378d04b95"},
+    {file = "pyobjc_framework_coremedia-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c91e5084f88f5716ad3d390af29ad52b8497a73df91dc6d05ebaa293ce3634cc"},
+    {file = "pyobjc_framework_coremedia-11.1.tar.gz", hash = "sha256:82cdc087f61e21b761e677ea618a575d4c0dbe00e98230bf9cea540cff931db3"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coremediaio"
+version = "11.1"
+description = "Wrappers for the framework CoreMediaIO on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"11.0\""
+files = [
+    {file = "pyobjc_framework_coremediaio-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:49120679162416ad5a4cf67b49830cf3d38b60bd94496e2a4cad3895496b558d"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4438713ee4611d5310f4f2e71e557b6138bc79c0363e3d45ecb8c09227dfa58e"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39ad2518de9943c474e5ca0037e78f92423c3352deeee6c513a489016dac1266"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e0a079fe790ce8a69d11bea46b315c9a0d3f3999a2f09e2ef4fcc4430a47c42"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5a94f9e507b470ce7dcb887e79ccf19e98693a606ad34462d711004e3edd88c3"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:0a7ffded00a7dc6f0bf4a44a6832f0150d45a83886486148b71ccc67c70ef215"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:5ff161025ef28d5e2eed90db0e8b828cb361281b799b16b1885711ca0addc1aa"},
+    {file = "pyobjc_framework_coremediaio-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c9499831def7220cd69db7c0009e64c8f5c39f8cbed761f98cf27da57461d923"},
+    {file = "pyobjc_framework_coremediaio-11.1.tar.gz", hash = "sha256:bccd69712578b177144ded398f4695d71a765ef61204da51a21f0c90b4ad4c64"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coremidi"
+version = "11.1"
+description = "Wrappers for the framework CoreMIDI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coremidi-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5dbd846a2c3f23795a49f363c1e22f0dd4d91ac675f9d52fb5ba93a2bd212d1f"},
+    {file = "pyobjc_framework_coremidi-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5f8c2fdc9d1b7967e2a5ec0d5281eaddc00477bed9753aa14d5b881dc3a9ad8f"},
+    {file = "pyobjc_framework_coremidi-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:deb9120478a831a898f22f68737fc683bb9b937e77556e78b75986aebd349c55"},
+    {file = "pyobjc_framework_coremidi-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c2e1ab122501206ceae07123fdc433e91a5f1a97224f80ece0717b6f36ad2029"},
+    {file = "pyobjc_framework_coremidi-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3462a158214adb7ebc785fb6924e674c58dcd471888dbca5e2e77381f3f1bbdc"},
+    {file = "pyobjc_framework_coremidi-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f4b70864cae295f27b5d51817c0768fade7c1335a59410910146e5f2a54c475c"},
+    {file = "pyobjc_framework_coremidi-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:2ef1a10f6230fce82b931670470158404657d9fb9ac558a77b46b547e9978524"},
+    {file = "pyobjc_framework_coremidi-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6d3d6ff84e41416e7ebc1c4bf1ffcafd5e9931985e45e84818bbb52b51f9629e"},
+    {file = "pyobjc_framework_coremidi-11.1.tar.gz", hash = "sha256:095030c59d50c23aa53608777102bc88744ff8b10dfb57afe24b428dcd12e376"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coreml"
+version = "11.1"
+description = "Wrappers for the framework CoreML on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"17.0\""
+files = [
+    {file = "pyobjc_framework_coreml-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b1b1b849ca91e0d62ed6dfd200d95ca8d023d6edff854aae77ba54eb0542415f"},
+    {file = "pyobjc_framework_coreml-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b5be7889ad99da1aca040238fd99af9ee87ea8a6628f24d33e2e4890b88dd139"},
+    {file = "pyobjc_framework_coreml-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c768b03d72488b964d753392e9c587684961d8237b69cca848b3a5a00aea79c9"},
+    {file = "pyobjc_framework_coreml-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:10d51f8a5fe8d30c7ec70304a2324df76b48b9fbef30ee0f0c33b99a49ae8853"},
+    {file = "pyobjc_framework_coreml-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4df25ee233430f016ffcb4e88506b54c8e7b668c93197e6a1341761530a5922c"},
+    {file = "pyobjc_framework_coreml-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:287a2a059016d02d8c40e0d29e70226142a4969db97ad79cefc70ec9bf0ab29e"},
+    {file = "pyobjc_framework_coreml-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a479c3d759aff3695f72c7915a78df6e92e0eca7027abaa8b4a07e876ba1dbfb"},
+    {file = "pyobjc_framework_coreml-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:25e6e2185aefc46eb2a796eee6f4bef1cba3206f914b85ac659699468e9dc9a8"},
+    {file = "pyobjc_framework_coreml-11.1.tar.gz", hash = "sha256:775923eefb9eac2e389c0821b10564372de8057cea89f1ea1cdaf04996c970a7"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coremotion"
+version = "11.1"
+description = "Wrappers for the framework CoreMotion on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_coremotion-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:87e642511279c080dd9d0c7b0af3903191a6400a6c3a3caeb54233cb642a6966"},
+    {file = "pyobjc_framework_coremotion-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:501248a726816e05552d1c1f7e2be2c7305cda792c46905d9aee7079dfad2eea"},
+    {file = "pyobjc_framework_coremotion-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8c3b33228a170bf8495508a8923451ec600435c7bff93d7614f19c913baeafd1"},
+    {file = "pyobjc_framework_coremotion-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac5302deaab99a7443cad63f125061a90040852d4f8efb58492542a612b2afe3"},
+    {file = "pyobjc_framework_coremotion-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d67413a56989154dab7bf1b69c14b0b2387d87d3a4c8e3c8a9fc0230f061e8ab"},
+    {file = "pyobjc_framework_coremotion-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:42fb307b86999d078503ff79bdf8df4d1c27d38763db6b1c5c0f4054241f67a3"},
+    {file = "pyobjc_framework_coremotion-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:708431c53f483bc6da199375227ffea1b4e8e7d8c81d162492db3fc36893fb53"},
+    {file = "pyobjc_framework_coremotion-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6665a5cfce8c12c06cdaacce2c2d781b7b5b831c004a6f39bf893d22001f366e"},
+    {file = "pyobjc_framework_coremotion-11.1.tar.gz", hash = "sha256:5884a568521c0836fac39d46683a4dea3d259a23837920897042ffb922d9ac3e"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coreservices"
+version = "11.1"
+description = "Wrappers for the framework CoreServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coreservices-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:96578c31035fed361d030b0168ae5fc593aa26aa78f6c9946b8da6007e46e08e"},
+    {file = "pyobjc_framework_coreservices-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f7260e09a0550d57756ad655f3d3815f21fc3f0386aed014be4b46194c346941"},
+    {file = "pyobjc_framework_coreservices-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6bd313ec326efd715b4b10c3ebcc9f054e3ee3178be407b97ea225cd871351d2"},
+    {file = "pyobjc_framework_coreservices-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8aee505dca56afc5363d8d0dff0b2d26583a8d0f3ac37674cef86f66c51a2934"},
+    {file = "pyobjc_framework_coreservices-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4ffa188322ab9d05c6964926959dedba5cc04534232f1eff03aee5f09faa499e"},
+    {file = "pyobjc_framework_coreservices-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:21e9e86192d719cd5c899cc0e931110733da0b5bbbf606681e5fccd4dd39c174"},
+    {file = "pyobjc_framework_coreservices-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:74dcc295245f07754328bada9577b189e3abef71607d013e939751c1b5b55729"},
+    {file = "pyobjc_framework_coreservices-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9738f624954a483d2380584a96034fc0a979136bfdedfb9f95d095c7033f2e9a"},
+    {file = "pyobjc_framework_coreservices-11.1.tar.gz", hash = "sha256:cf8eb5e272c60a96d025313eca26ff2487dcd02c47034cc9db39f6852d077873"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-FSEvents = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-corespotlight"
+version = "11.1"
+description = "Wrappers for the framework CoreSpotlight on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"17.0\""
+files = [
+    {file = "pyobjc_framework_corespotlight-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b2d3ddabf74ef04933eb28b1a1c5ed93748b31e64b9c29d5eb88fafab5605c87"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d3c571289ce9107f1ade92ad036633f81355f22f70e8ba82d7335f1757381b89"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7cedd3792fe1fe2a8dc65a8ff1f70baf12415a5dc9dc4d88f987059567d7e694"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:546d0d9b101de4ca20449f3807d1f88e5c26de0345a8bfefc70f12f87efb8433"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f562cc65865066f8e2e5d96c868fd7f463d8280f1ef01df85250fc1150feed0e"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bce3d84f97014228b244c734aea3ec03b257573b22c097dff4eb176a80cd29a9"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:f59d0d2f0411db102d16490e47b457b994c613f1b980869fa3a151863da7aa4c"},
+    {file = "pyobjc_framework_corespotlight-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9c5f8848cd69091fa88fae575a00c3fa6159f6022b4aabc5356595aa16ef2fa0"},
+    {file = "pyobjc_framework_corespotlight-11.1.tar.gz", hash = "sha256:4dd363c8d3ff7619659b63dd31400f135b03e32435b5d151459ecdacea14e0f2"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "11.1"
+description = "Wrappers for the framework CoreText on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coretext-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:515be6beb48c084ee413c00c4e9fbd6e730c1b8a24270f4c618fc6c7ba0011ce"},
+    {file = "pyobjc_framework_coretext-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4f4d2d2a6331fa64465247358d7aafce98e4fb654b99301a490627a073d021e"},
+    {file = "pyobjc_framework_coretext-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1597bf7234270ee1b9963bf112e9061050d5fb8e1384b3f50c11bde2fe2b1570"},
+    {file = "pyobjc_framework_coretext-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37e051e8f12a0f47a81b8efc8c902156eb5bc3d8123c43e5bd4cebd24c222228"},
+    {file = "pyobjc_framework_coretext-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56a3a02202e0d50be3c43e781c00f9f1859ab9b73a8342ff56260b908e911e37"},
+    {file = "pyobjc_framework_coretext-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:15650ba99692d00953e91e53118c11636056a22c90d472020f7ba31500577bf5"},
+    {file = "pyobjc_framework_coretext-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:fb27f66a56660c31bb956191d64b85b95bac99cfb833f6e99622ca0ac4b3ba12"},
+    {file = "pyobjc_framework_coretext-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7fee99a1ac96e3f70d482731bc39a546da82a58f87fa9f0e2b784a5febaff33d"},
+    {file = "pyobjc_framework_coretext-11.1.tar.gz", hash = "sha256:a29bbd5d85c77f46a8ee81d381b847244c88a3a5a96ac22f509027ceceaffaf6"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-corewlan"
+version = "11.1"
+description = "Wrappers for the framework CoreWLAN on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_corewlan-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8a30698aea3a2c5130f4ff309bda45029f66ef76574d3cefce6159e9a5cc6bdd"},
+    {file = "pyobjc_framework_corewlan-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e12f127b37a7ab8f349167332633392f2d6d29b87c9b98137a289d0fc1e07b5b"},
+    {file = "pyobjc_framework_corewlan-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7bd0775d2466ad500aad4747d8a889993db3a14240239f30ef53c087745e9c8e"},
+    {file = "pyobjc_framework_corewlan-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3c66643a97fcf3aa797fda997a3afc28d8d9bba9727dd5c0e68a313899d780f7"},
+    {file = "pyobjc_framework_corewlan-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6dc28264b56b18096c8869cce3f85e519fd27936f19524bb77458572ccfd7518"},
+    {file = "pyobjc_framework_corewlan-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:872de75409a710bb9a461e64e97185f8489d01898ec1b02c3e058c04606b61cf"},
+    {file = "pyobjc_framework_corewlan-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:14c7af9135ba0a920192af4dc50219bbf6185fcbb5de7041f097e1a1c8509587"},
+    {file = "pyobjc_framework_corewlan-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c5e00a907c7b92daff716c35f4958083495327f7d6bc1f061339499114999ebf"},
+    {file = "pyobjc_framework_corewlan-11.1.tar.gz", hash = "sha256:4a8afea75393cc0a6fe696e136233aa0ed54266f35a47b55a3583f4cb078e6ce"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-cryptotokenkit"
+version = "11.1"
+description = "Wrappers for the framework CryptoTokenKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d53ef13571afab5b2df5b2c118c3f296abae095abe6f0c9ebd105bab31527369"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b76fb928bc398091141dc52b26e02511065afd0b6de5533fa0e71ab13c51589"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6384cb1d86fc586e2da934a5a37900825bd789e3a5df97517691de9af354af0c"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a55c0e57ab164aa5ce562e4d9e69026339067ecb4888638995690f1c43b79cfa"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:cb3e1bd344e794cb98343171b5501a1a3b75548ef5385bda3d5ec613c0b98045"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:faab9493e36095c0257598e25ef81c50bcdb3afb5843a82e6dfad8c7d1f47bcf"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:efd89e5b024475701f6e9bec4cf1c2563e1bab37e79288397e09d9ad4e53d174"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4d7d3e54d661527c7a075f38387880cd6ec82288ce1b52f5f197b94a6909d107"},
+    {file = "pyobjc_framework_cryptotokenkit-11.1.tar.gz", hash = "sha256:5f82f44d9ab466c715a7c8ad4d5ec47c68aacd78bd67b5466a7b8215a2265328"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-datadetection"
+version = "11.1"
+description = "Wrappers for the framework DataDetection on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_datadetection-11.1-py2.py3-none-any.whl", hash = "sha256:5afd3dde7bba3324befb7a3133c9aeaa5088efd72dccc0804267a74799f4a12f"},
+    {file = "pyobjc_framework_datadetection-11.1.tar.gz", hash = "sha256:cbe0080b51e09b2f91eaf2a9babec3dcf2883d7966bc0abd8393ef7abfcfc5db"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-devicecheck"
+version = "11.1"
+description = "Wrappers for the framework DeviceCheck on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_devicecheck-11.1-py2.py3-none-any.whl", hash = "sha256:8edb36329cdd5d55e2c2c57c379cb5ba1f500f74a08fe8d2612b1a69b7a26435"},
+    {file = "pyobjc_framework_devicecheck-11.1.tar.gz", hash = "sha256:8b05973eb2673571144d81346336e749a21cec90bd7fcaade76ffd3b147a0741"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-devicediscoveryextension"
+version = "11.1"
+description = "Wrappers for the framework DeviceDiscoveryExtension on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"24.0\""
+files = [
+    {file = "pyobjc_framework_devicediscoveryextension-11.1-py2.py3-none-any.whl", hash = "sha256:96e5b13c718bd0e6c80fbd4e14b8073cffc88b3ab9bb1bbb4dab7893a62e4f11"},
+    {file = "pyobjc_framework_devicediscoveryextension-11.1.tar.gz", hash = "sha256:ae160ea40f25d3ee5e7ce80ac9c1b315f94d0a4c7ccb86920396f71c6bf799a0"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-dictionaryservices"
+version = "11.1"
+description = "Wrappers for the framework DictionaryServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"9.0\""
+files = [
+    {file = "pyobjc_framework_dictionaryservices-11.1-py2.py3-none-any.whl", hash = "sha256:92f4871066653f18e2394ac93b0a2ab50588d60020f6b3bd93e97b67cd511326"},
+    {file = "pyobjc_framework_dictionaryservices-11.1.tar.gz", hash = "sha256:39c24452d0ddd037afeb73a1742614c94535f15b1c024a8a6cc7ff081e1d22e7"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-CoreServices = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-discrecording"
+version = "11.1"
+description = "Wrappers for the framework DiscRecording on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_discrecording-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9bae2419669ec3aadd3e7bf98dd92c80839242c7af4ab94364f5008cfe8e5603"},
+    {file = "pyobjc_framework_discrecording-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dc8a7820fc193c2bfcd843c31de945dc45e77e5413089eabbc72be16a4f52e53"},
+    {file = "pyobjc_framework_discrecording-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e29bc8c3741ae52fae092f892de856dbab2363e71537a8ae6fd026ecb88e2252"},
+    {file = "pyobjc_framework_discrecording-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2d18158366d124852ad58291954611ebdcc43263a3bb75d7fd273408e67720e2"},
+    {file = "pyobjc_framework_discrecording-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b027eca3a0391196d4335fcbd50c03ef1e8f5ce095411ed51a081328b4945bf5"},
+    {file = "pyobjc_framework_discrecording-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:9cb36715bebdbbe1ad95e3c17359c2f5d3f6479a26b527ea1032154ca7cf3e09"},
+    {file = "pyobjc_framework_discrecording-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:7c33421d6bed0993d9f1861dbf38b717b9a9e49dfb98fdf8b3cd8d558fdd50eb"},
+    {file = "pyobjc_framework_discrecording-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f94ca724139d63bb1fb91ad528c5ca903bcec0e4fcfdc5f51959853aad6a8eec"},
+    {file = "pyobjc_framework_discrecording-11.1.tar.gz", hash = "sha256:37585458e363b20bb28acdb5cc265dfca934d8a07b7baed2584953c11c927a87"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-discrecordingui"
+version = "11.1"
+description = "Wrappers for the framework DiscRecordingUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_discrecordingui-11.1-py2.py3-none-any.whl", hash = "sha256:33233b87d7b85ce277a51d27acca0f5b38485cf1d1dc8e28a065910047766ee2"},
+    {file = "pyobjc_framework_discrecordingui-11.1.tar.gz", hash = "sha256:a9f10e2e7ee19582c77f0755ae11a64e3d61c652cbd8a5bf52756f599be24797"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-DiscRecording = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-diskarbitration"
+version = "11.1"
+description = "Wrappers for the framework DiskArbitration on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_diskarbitration-11.1-py2.py3-none-any.whl", hash = "sha256:6a8e551e54df481a9081abba6fd680f6633babe5c7735f649731b22896bb6f08"},
+    {file = "pyobjc_framework_diskarbitration-11.1.tar.gz", hash = "sha256:a933efc6624779a393fafe0313e43378bcae2b85d6d15cff95ac30048c1ef490"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-dvdplayback"
+version = "11.1"
+description = "Wrappers for the framework DVDPlayback on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_dvdplayback-11.1-py2.py3-none-any.whl", hash = "sha256:6094e4651ea29540ac817294b27e1596b9d1883d30e78fb5f9619daf94ed30cb"},
+    {file = "pyobjc_framework_dvdplayback-11.1.tar.gz", hash = "sha256:b44c36a62c8479e649133216e22941859407cca5796b5f778815ef9340a838f4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-eventkit"
+version = "11.1"
+description = "Wrappers for the framework Accounts on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_eventkit-11.1-py2.py3-none-any.whl", hash = "sha256:c303207610d9c742f4090799f60103cede466002f3c89cf66011c8bf1987750b"},
+    {file = "pyobjc_framework_eventkit-11.1.tar.gz", hash = "sha256:5643150f584243681099c5e9435efa833a913e93fe9ca81f62007e287349b561"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-exceptionhandling"
+version = "11.1"
+description = "Wrappers for the framework ExceptionHandling on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_exceptionhandling-11.1-py2.py3-none-any.whl", hash = "sha256:31e6538160dfd7526ac0549bc0fce5d039932aea84c36abbe7b49c79ffc62437"},
+    {file = "pyobjc_framework_exceptionhandling-11.1.tar.gz", hash = "sha256:e010f56bf60ab4e9e3225954ebb53e9d7135d37097043ac6dd2a3f35770d4efa"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-executionpolicy"
+version = "11.1"
+description = "Wrappers for the framework ExecutionPolicy on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_executionpolicy-11.1-py2.py3-none-any.whl", hash = "sha256:7d4141e572cb916e73bb34bb74f6f976a8aa0a396a0bffd1cf66e5505f7c76c8"},
+    {file = "pyobjc_framework_executionpolicy-11.1.tar.gz", hash = "sha256:3280ad2f4c5eaf45901f310cee0c52db940c0c63e959ad082efb8df41055d986"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-extensionkit"
+version = "11.1"
+description = "Wrappers for the framework ExtensionKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_extensionkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:eb766b18ba23f15eeb1235c2a42f487591ff905644f9f12e44efe987ce3fbd38"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:61fd9f9758f95bcff2bf26fe475f679dfff9457d7130f114089e88fd5009675a"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d505a64617c9db4373eb386664d62a82ba9ffc909bffad42cb4da8ca8e244c66"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:abbadbea5b18e4a6944c3c428753ee298a133cbf601c70e9586b14e3aebf649b"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5c2e203cb8134be1dd7df73d74c630adbaaf43d78eba04be451ea4f8bf582e22"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3507f67dd06285c09bbdf5216a1148f5dd3a2f10eee7a9318dd14430bf6e67ee"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:2767635e57b277e051719fa53c7683396ebdbcf3d40d44c1296758978ca8c92a"},
+    {file = "pyobjc_framework_extensionkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a3ac9001319f8276d3dee74816c7db6c0d32dfe2db31ad720051d284bb245dbe"},
+    {file = "pyobjc_framework_extensionkit-11.1.tar.gz", hash = "sha256:c114a96f13f586dbbab8b6219a92fa4829896a645c8cd15652a6215bc8ff5409"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-externalaccessory"
+version = "11.1"
+description = "Wrappers for the framework ExternalAccessory on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"17.0\""
+files = [
+    {file = "pyobjc_framework_externalaccessory-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a36e2718d364373b10ac7b8151cffe8e3dedfcc72470fe2b6eed4e9c5d954034"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a2b22f72b83721d841e5a3128df29fc41d785597357c6bbce84555a2b51a1e9d"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:00caf75b959db5d14118d78c04085e2148255498839cdee735a0b9f6ef86b6a2"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:50b796a4721db87863a28cd55668cb1547fcc28834afda2032e500cdab5b3d95"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:569124b686569c48e3855fff128f438a2b46af06280eac2a516aaa214ad325de"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:318772e698c6363e8c3c81229d93b639f5066a02a742ba1ab10cfdef3101d88b"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d259724665617fc4f3e666d353b756a67cabb74e6f9d7b8f6f250a2d4bf05cb7"},
+    {file = "pyobjc_framework_externalaccessory-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:939b6d221986da187d588f7340f7468eeca2f60a86a6dd0b2625d58e69537946"},
+    {file = "pyobjc_framework_externalaccessory-11.1.tar.gz", hash = "sha256:50887e948b78a1d94646422c243ac2a9e40761675e38b9184487870a31e83371"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-fileprovider"
+version = "11.1"
+description = "Wrappers for the framework FileProvider on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_fileprovider-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:17e0da2e00900a1b25aca1cdbbda2c8097573ce07d6650d572968dff45c06ca7"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:888d6fb3fd625889ce0e409320c3379330473a386095cb4eda2b4caf0198ff66"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ce6092dfe74c78c0b2abc03bfc18a0f5d8ddc624fc6a1d8dfef26d7796653072"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9af41255df395a40a6e0b08c4410be5463f3ea91d8c9be61f6bd114252490ab2"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d2720acdd582756ebda34418981e7646b7b85588b0b8fdafba7016eb657be6b8"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:0e48015bf50b3e56312c640ec6efde73cf3855e29b6d70d173a88957d9d74d27"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:95ed3a03741076a4479aabb616b1e3ea022025a0ad842147a1200c27709019e2"},
+    {file = "pyobjc_framework_fileprovider-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e55b6f15990c5677804a58e412fdfce33e442f14626f80f9fe5d8b2542254a24"},
+    {file = "pyobjc_framework_fileprovider-11.1.tar.gz", hash = "sha256:748ca1c75f84afdf5419346a24bf8eec44dca071986f31f00071dc191b3e9ca8"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-fileproviderui"
+version = "11.1"
+description = "Wrappers for the framework FileProviderUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_fileproviderui-11.1-py2.py3-none-any.whl", hash = "sha256:f2765f114c2f4356aa41fb45c621fa8f0a4fae0b6d3c6b1a274366f5fe7fe829"},
+    {file = "pyobjc_framework_fileproviderui-11.1.tar.gz", hash = "sha256:162a23e67f59e1bb247e84dda88d513d7944d815144901a46be6fe051b6c7970"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-FileProvider = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-findersync"
+version = "11.1"
+description = "Wrappers for the framework FinderSync on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_findersync-11.1-py2.py3-none-any.whl", hash = "sha256:c72b0fd8b746b99cfa498da36c5bb333121b2080ad73fa8cbea05cd47db1fa82"},
+    {file = "pyobjc_framework_findersync-11.1.tar.gz", hash = "sha256:692364937f418f0e4e4abd395a09a7d4a0cdd55fd4e0184de85ee59642defb6e"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-fsevents"
+version = "11.1"
+description = "Wrappers for the framework FSEvents on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_fsevents-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0f51d55e94fd84bc585a5c4ee63634297e192b256298a1372405649054220d13"},
+    {file = "pyobjc_framework_fsevents-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:95cc5d839d298b8e95175fb72df8a8e1b08773fd2e0d031efe91eee23e0c8830"},
+    {file = "pyobjc_framework_fsevents-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8b51d120b8f12a1ca94e28cf74113bf2bfd4c5aee7035b452e895518f4df7630"},
+    {file = "pyobjc_framework_fsevents-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fad5ada269f137afabd622b5fc04884c668ae1c7914a8791bab73b1d972f7713"},
+    {file = "pyobjc_framework_fsevents-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ff064cfa9d9cffb5d4ab476fb5091604568744d961c670aced037b2b6f0d0185"},
+    {file = "pyobjc_framework_fsevents-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:9191ee2819f1d5dcae1559e4a66f19be03da3a103bccdc417e6888bcb5659f8f"},
+    {file = "pyobjc_framework_fsevents-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3289192f4d60e5b26f8ac88ae4049a11eff47caa6fb76ce34e3f7df405119905"},
+    {file = "pyobjc_framework_fsevents-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c71b15d7a9d85b54882f01ebbde7e6a643dbd1537edbb92400b933e848704fc0"},
+    {file = "pyobjc_framework_fsevents-11.1.tar.gz", hash = "sha256:d29157d04124503c4dfa9dcbbdc8c34d3bab134d3db3a48d96d93f26bd94c14d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-fskit"
+version = "11.1"
+description = "Wrappers for the framework FSKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"24.4\""
+files = [
+    {file = "pyobjc_framework_fskit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:db96e20789186b5f3be132cc7041e38cdaf98904da82b80fbcb2564365738517"},
+    {file = "pyobjc_framework_fskit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:59a939ac8442d648f73a3da75923aa3637ac4693850d995f1914260c8f4f7947"},
+    {file = "pyobjc_framework_fskit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e50b8f949f1386fada73b408463c87eb81ef7fd0b3482bacf0c206a73723013"},
+    {file = "pyobjc_framework_fskit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cc2390934a23b6407aa7802b11978374301444c3135835ad3373f7b4930c24eb"},
+    {file = "pyobjc_framework_fskit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:44fe7b6781c8fd0552b13ab3d0ec21176cd7cd685a8a61d712f9e4e42eb2f736"},
+    {file = "pyobjc_framework_fskit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:1d3793938e6d9b871483d4a6fad8f93d554bcbebd1fe7bed20e3f5d2feaa814b"},
+    {file = "pyobjc_framework_fskit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e38f9c449647109e5b14dc4a17f425efca10c7e539a3836ebdd1f9c0ef725a3b"},
+    {file = "pyobjc_framework_fskit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3d6b9725d341fa7c2a0e383fd1dbf2c20c7506bb97d9df40120a2d6de0a99be8"},
+    {file = "pyobjc_framework_fskit-11.1.tar.gz", hash = "sha256:9ded1eab19b4183cb04381e554bbbe679c1213fd58599d6fc6e135e93b51136f"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-gamecenter"
+version = "11.1"
+description = "Wrappers for the framework GameCenter on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_gamecenter-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8543725d4fad635bbbe3aaeea0df8d31a419f2cab0d9f9b411ae2212c8fac5eb"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:81abe136292ea157acb6c54871915fe6d386146a9386179ded0b974ac435045c"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:779cdf8f52348be7f64d16e3ea37fd621d5ee933c032db3a22a8ccad46d69c59"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ff8905a5a7bfd86cb2b95671b452be0836f79db065b8d8b3bb2a1a5750ffd0d"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a73ca7027b2b827e26075b46551fe42425d4a68985022baa4413329a3a2c16ff"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:2a2cb6471d4d4b19f124c7e91a32882a0fab6e326bb0415915fd8f3b91cfc311"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:90132bb32f5ed6607e13c6f39346ad621611cb92cea308ced661a6ba1305b94e"},
+    {file = "pyobjc_framework_gamecenter-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:46bf896c26684fad0c93f71cf3b5f44157034f0b7e18977d80405749b3d65deb"},
+    {file = "pyobjc_framework_gamecenter-11.1.tar.gz", hash = "sha256:a1c4ed54e11a6e4efba6f2a21ace92bcf186e3fe5c74a385b31f6b1a515ec20c"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-gamecontroller"
+version = "11.1"
+description = "Wrappers for the framework GameController on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_gamecontroller-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f19e4e645966e99c08552d0841c9e535326506dfc0c0ef097a6ad62f71b7e99d"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:782779f080508acf869187c0cbd3a48c55ee059d3a14fe89ccd6349537923214"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2cbc0c6c7d9c63e6b5b0b124d0c2bad01bb4b136f3cbc305f27d31f8aab6083"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4866b25df05f583af06095e7103ddd2fbb2484b0ac2c78fd2cd825f995e524fa"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:98f3f7afcbbe473a53537da42b2cdc0363df2647289eb66e8c762e4b46c23e73"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:de3892b8d09a65a3413d85a2f0762eba092afda8d97cbf9cda0417689cfb7027"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:afe9f3aed8c900ebe63ee4f6e53c73c2fef7e503f6388afd39f46b31487f84a3"},
+    {file = "pyobjc_framework_gamecontroller-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6dc5a5660668c988ad4d57cfc93877d9718ab617ef9322d6eac211a567708cad"},
+    {file = "pyobjc_framework_gamecontroller-11.1.tar.gz", hash = "sha256:4d5346faf90e1ebe5602c0c480afbf528a35a7a1ad05f9b49991fdd2a97f105b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-gamekit"
+version = "11.1"
+description = "Wrappers for the framework GameKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_gamekit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:18ce0e373613a0b9f78969218b884c3191958e353e3462fbfc6d51d758ada41c"},
+    {file = "pyobjc_framework_gamekit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5e07c25eab051905c6bd46f368d8b341ef8603dce588ff6dbd82d609dd4fbf71"},
+    {file = "pyobjc_framework_gamekit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f945c7cfe53c4a349a03a1272f2736cc5cf88fe9e7a7a407abb03899635d860c"},
+    {file = "pyobjc_framework_gamekit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c7f2bf7ecf44ca678cfdf76f23b32d9c2d03006a0af9ad8e60d9114d6be640a"},
+    {file = "pyobjc_framework_gamekit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a7c8fce8a2c4614e3dd88b002540e67423e3efd41aa26d576db2de0fc61651b9"},
+    {file = "pyobjc_framework_gamekit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:555cb8d868fd2699ad70d4f9e7efccaa5df1995893050d05d478cb8f24dbf876"},
+    {file = "pyobjc_framework_gamekit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:10331a69282b9554ce7ae618dc9ff68e96451759f6cfc687e188c82ba6b0e2ff"},
+    {file = "pyobjc_framework_gamekit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fb9e8c59efbda8476f4411cab71d05a23cb85cc77c58e5b52852692d1d7206c0"},
+    {file = "pyobjc_framework_gamekit-11.1.tar.gz", hash = "sha256:9b8db075da8866c4ef039a165af227bc29393dc11a617a40671bf6b3975ae269"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-gameplaykit"
+version = "11.1"
+description = "Wrappers for the framework GameplayKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_gameplaykit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8cc9b2a476f79d593d9617fdb8c5ac27d1cf9256063379e3df9b6519c462eb48"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac9f50941988c30175149af481a49b2026c56a9a497c6dbf2974ffb50ffe0af8"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e4f34db8177b8b4d89fd22a2a882a6c9f6e50cb438ea2fbbf96845481bcd80d"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:78c513bc53bafd996d896f6f4535f2700b4916013417f8b41f47045790c6208d"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:30e15e4e8df9b1c0ca92bfabf79f6b12a286e544e67762b14dd3023c53e41978"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:4dbea3471b5d4a82b37ddca41bfddd63380c31050de7392e2467fabebcd110b8"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:51abecafc1b55fcc9a5d73c078ea2d5a75964e0facf2c867a25d7f4f40238331"},
+    {file = "pyobjc_framework_gameplaykit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70dc72e8b59c0c64a825057d14a5a5a2cec8c95d0f710da1b83fb8a989ac8380"},
+    {file = "pyobjc_framework_gameplaykit-11.1.tar.gz", hash = "sha256:9ae2bee69b0cc1afa0e210b4663c7cdbb3cc94be1374808df06f98f992e83639"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-SpriteKit = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-healthkit"
+version = "11.1"
+description = "Wrappers for the framework HealthKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_healthkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f15f2cff20a09f42f251752f908a54c5fe3adabb03ec8d3fb2b66ff7b0b4709e"},
+    {file = "pyobjc_framework_healthkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:34bce3d144c461af7e577fcf6bbb7739d0537bf42f081960122923a7ef2e06c0"},
+    {file = "pyobjc_framework_healthkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab4350f9fe65909107dd7992b367a6c8aac7dc31ed3d5b52eeb2310367d0eb0b"},
+    {file = "pyobjc_framework_healthkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8b6c739e17362897f0b1ba4aa4dc395b3d0c3855b87423eaeb6a89f910adc43f"},
+    {file = "pyobjc_framework_healthkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2d1b76b04e9e33ac9441cafa695766938eac04f8c8c69f7efd93a6aceb6eca40"},
+    {file = "pyobjc_framework_healthkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:547ac283f84b5024be75290f351863f86eb48a950ec61e3150760230e6eba773"},
+    {file = "pyobjc_framework_healthkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:c693725d8476b745232df90ef01487e75e1e1c448e599dd34adf3dce859de760"},
+    {file = "pyobjc_framework_healthkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:356ea404bee0b477269f494aad63386b5295218034ca8327e4047ece4c31ccfb"},
+    {file = "pyobjc_framework_healthkit-11.1.tar.gz", hash = "sha256:20f59bd9e1ffafe5893b4eff5867fdfd20bd46c3d03bc4009219d82fc6815f76"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-imagecapturecore"
+version = "11.1"
+description = "Wrappers for the framework ImageCaptureCore on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:69f91c9f17bf0b8332b5826033bc5292493fe575fdb841cd7f58ab493053de38"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ede4c15da909a4d819c732a5554b8282a7b56a1b73d82aef908124147921945a"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed296c23d3d8d1d9af96a6486d09fb8d294cc318e4a2152e6f134151c76065f8"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ded8dc6a8c826a6ae1b6a6d0a31542bd1eb85345f86201689c54e51193b572dc"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:254ae4502d651526c500533b8e2aee77ae7939f9acfd7d706dba2d464417deba"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bab8ed798598ddaa53f5b39707b58e16a1b1152858c87fd3fa0d64081f0c0364"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e01c29456d0560667f8fcd3ff2749e79ad51bf72512e699646ce32227f91b447"},
+    {file = "pyobjc_framework_imagecapturecore-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5334e55f13cf929e5bcddbd852dd74136201f2fb563cf7d6066579d907a25c81"},
+    {file = "pyobjc_framework_imagecapturecore-11.1.tar.gz", hash = "sha256:a610ceb6726e385b132a1481a68ce85ccf56f94667b6d6e1c45a2cfab806a624"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-inputmethodkit"
+version = "11.1"
+description = "Wrappers for the framework InputMethodKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"9.0\""
+files = [
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7ccf8697a13e7ab5e3ec446b930f40069da43823bfc678c4c426ad03f980c14f"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9b0e47c3bc7f1e628c906436c1735041ed2e9aa7cba3f70084b6311c63c508be"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dd0c591a9d26967018a781fa4638470147ef2a9af3ab4a28612f147573eeefba"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5095005809a4108f362998b46994f99b5a57f9ba367c01141c1b9eaea311bc5b"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:013919a4d766a7e66045fa5dd5d819bfa0450ccb59baba2b89d7449bce637d6b"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:2228bf58369351767294fe1aa400e98ec61e397a74a178788c24c98a1cff97ee"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:92b9ce788ce4b094e352a64508050ff8e24307b8670d33488304b941d118894e"},
+    {file = "pyobjc_framework_inputmethodkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e18862d58addf13ff3592c43a4fc70f0b6f38b5d7e53358cf78b33b9a2b2c00e"},
+    {file = "pyobjc_framework_inputmethodkit-11.1.tar.gz", hash = "sha256:7037579524041dcee71a649293c2660f9359800455a15e6a2f74a17b46d78496"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-installerplugins"
+version = "11.1"
+description = "Wrappers for the framework InstallerPlugins on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_installerplugins-11.1-py2.py3-none-any.whl", hash = "sha256:f92b06c9595f3c800b7aabf1c1a235bfb4b2de3f5406d5f604d8e2ddd0aecb4e"},
+    {file = "pyobjc_framework_installerplugins-11.1.tar.gz", hash = "sha256:363e59c7e05553d881f0facd41884f17b489ff443d7856e33dd0312064c746d9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-instantmessage"
+version = "11.1"
+description = "Wrappers for the framework InstantMessage on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"9.0\""
+files = [
+    {file = "pyobjc_framework_instantmessage-11.1-py2.py3-none-any.whl", hash = "sha256:a70b716e279135eec5666af031f536c0f32dec57cfeae55cc9ff8457f10d4f3d"},
+    {file = "pyobjc_framework_instantmessage-11.1.tar.gz", hash = "sha256:c222aa61eb009704b333f6e63df01a0e690136e7e495907e5396882779bf9525"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-intents"
+version = "11.1"
+description = "Wrappers for the framework Intents on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"16.0\""
+files = [
+    {file = "pyobjc_framework_intents-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:315f8572336dee42ab582435e85176a14455928ac451fcb1f7c62786d17e8758"},
+    {file = "pyobjc_framework_intents-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:da2f11ee64c75cfbebb1c2be52a20b3618f32b6c47863809ff64c61e8a1dffb9"},
+    {file = "pyobjc_framework_intents-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a663e2de1b7ae7b547de013f89773963f8180023e36f2cebfe8060395dc34c33"},
+    {file = "pyobjc_framework_intents-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e21b3bc33de2d5f69b5c1d581e5c724a08686fe84ec324a4be365bef769e482"},
+    {file = "pyobjc_framework_intents-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e008d542abe38fd374c9ada7c833ad6e34a2db92b4dcbfba0a59ff830b9093bc"},
+    {file = "pyobjc_framework_intents-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:55498040123904b685cd38555eb84d95833fcb467b497d31757d6ac648a11817"},
+    {file = "pyobjc_framework_intents-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:4e3ec70c02d3166088223938a7433e479659cbd8ce04be5bf515ea8d6e3c353d"},
+    {file = "pyobjc_framework_intents-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1c915ab478cc0a47894e78adb9bdbad4ec32a8b227bde91f9713dd61015d3ea8"},
+    {file = "pyobjc_framework_intents-11.1.tar.gz", hash = "sha256:13185f206493f45d6bd2d4903c2136b1c4f8b9aa37628309ace6ff4a906b4695"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-intentsui"
+version = "11.1"
+description = "Wrappers for the framework Intents on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_intentsui-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:381c14d60170f71e89b5fd4eae84c0821c50a70b08ce9994286177fa37b8d79e"},
+    {file = "pyobjc_framework_intentsui-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:252f7833fabb036cd56d59b445922b25cda1561b54c0989702618a5561d8e748"},
+    {file = "pyobjc_framework_intentsui-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:99a3ae40eb2a6ef1125955dd513c8acc88ce7d8d90130a8cdeaec8336e6fbec5"},
+    {file = "pyobjc_framework_intentsui-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:154fd92112184e8ef29ce81e685c377422dffcff4f7900ea6e5956a0e2be2268"},
+    {file = "pyobjc_framework_intentsui-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6d7d5402c05840a45047cf905fa550c2898cf5580cdee00a36bd35dd624c7542"},
+    {file = "pyobjc_framework_intentsui-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:35ef9f190f480147ce797809a63cc2b5f2ea64b51255d691e5e94bd8337e01ef"},
+    {file = "pyobjc_framework_intentsui-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:1bd950f808efb7ba7fbbc977300d7932a1dad41fbd3c78c8002870ca602e22d5"},
+    {file = "pyobjc_framework_intentsui-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0541fdd4dfafc8ce2981784842548a50ba55d7fee121b5d3c4edf15af8c1391d"},
+    {file = "pyobjc_framework_intentsui-11.1.tar.gz", hash = "sha256:c8182155af4dce369c18d6e6ed9c25bbd8110c161ed5f1b4fb77cf5cdb99d135"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Intents = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-iobluetooth"
+version = "11.1"
+description = "Wrappers for the framework IOBluetooth on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_iobluetooth-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d512252b8ee2a23c88d5e0a188f8949858f1ef3b99c279fb412f3e00508ec367"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7d8858cf2e4b2ef5e8bf29b76c06d4f2e6a2264c325146d07dfab94c46633329"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:883781e7223cb0c63fab029d640721ded747f2e2b067645bc8b695ef02a4a4dd"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4a8b1caba9ac51435f64a6cf9c1a2be867603161af8bebdd1676072ebed2fed9"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2c99ade82a79263ea71c51d430696a2ad155beb01a67df59d52be63e181e0482"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:2ef72cef1e03468e91a2f01af2390143bd6e4fcad1c6d0494dd857c99fa0d1a7"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a9a7e11a4bbb4a364b0412ca8632a1e853270c98c24d28421133f69c0c0ecaff"},
+    {file = "pyobjc_framework_iobluetooth-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ea799de85cecfb50e5232b80d9966d0dad7cf63cad56317fb35b14b90f38dcd"},
+    {file = "pyobjc_framework_iobluetooth-11.1.tar.gz", hash = "sha256:094fd4be60cd1371b17cb4b33a3894e0d88a11b36683912be0540a7d51de76f1"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-iobluetoothui"
+version = "11.1"
+description = "Wrappers for the framework IOBluetoothUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_iobluetoothui-11.1-py2.py3-none-any.whl", hash = "sha256:3c5a382d81f319a1ab9ab11b7ead04e53b758fdfeb604755d39c3039485eaac6"},
+    {file = "pyobjc_framework_iobluetoothui-11.1.tar.gz", hash = "sha256:060c721f1cd8af4452493e8153b72b572edcd2a7e3b635d79d844f885afee860"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-IOBluetooth = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-iosurface"
+version = "11.1"
+description = "Wrappers for the framework IOSurface on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_iosurface-11.1-py2.py3-none-any.whl", hash = "sha256:0c36ad56f8ec675dd07616418a2bc29126412b54627655abd21de31bcafe2a79"},
+    {file = "pyobjc_framework_iosurface-11.1.tar.gz", hash = "sha256:a468b3a31e8cd70a2675a3ddc7176ab13aa521c035f11188b7a3af8fff8b148b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-ituneslibrary"
+version = "11.1"
+description = "Wrappers for the framework iTunesLibrary on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_ituneslibrary-11.1-py2.py3-none-any.whl", hash = "sha256:4e87d41f82acb6d98cf70ac3c932a568ceb3c2035383cbf177f54e63de6b815f"},
+    {file = "pyobjc_framework_ituneslibrary-11.1.tar.gz", hash = "sha256:e2212a9340e4328056ade3c2f9d4305c71f3f6af050204a135f9fa9aa3ba9c5e"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-kernelmanagement"
+version = "11.1"
+description = "Wrappers for the framework KernelManagement on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_kernelmanagement-11.1-py2.py3-none-any.whl", hash = "sha256:ec74690bd3383a7945c4a038cc4e1553ec5c1d2408b60e2b0003a3564bff7c47"},
+    {file = "pyobjc_framework_kernelmanagement-11.1.tar.gz", hash = "sha256:e934d1638cd89e38d6c6c5d4d9901b4295acee2d39cbfe0bd91aae9832961b44"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-latentsemanticmapping"
+version = "11.1"
+description = "Wrappers for the framework LatentSemanticMapping on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_latentsemanticmapping-11.1-py2.py3-none-any.whl", hash = "sha256:57f3b183021759a100d2847a4d8aa314f4033be3d2845038b62e5e823d96e871"},
+    {file = "pyobjc_framework_latentsemanticmapping-11.1.tar.gz", hash = "sha256:c6c3142301e4d375c24a47dfaeebc2f3d0fc33128a1c0a755794865b9a371145"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-launchservices"
+version = "11.1"
+description = "Wrappers for the framework LaunchServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_launchservices-11.1-py2.py3-none-any.whl", hash = "sha256:8b58f1156651058b2905c87ce48468f4799db86a7edf760e1897fedd057a3908"},
+    {file = "pyobjc_framework_launchservices-11.1.tar.gz", hash = "sha256:80b55368b1e208d6c2c58395cc7bc12a630a2a402e00e4930493e9bace22b7bb"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-CoreServices = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "11.1"
+description = "Wrappers for libdispatch on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_libdispatch-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9c598c073a541b5956b5457b94bd33b9ce19ef8d867235439a0fad22d6beab49"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2ddca472c2cbc6bb192e05b8b501d528ce49333abe7ef0eef28df3133a8e18b7"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dc9a7b8c2e8a63789b7cf69563bb7247bde15353208ef1353fff0af61b281684"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c4e219849f5426745eb429f3aee58342a59f81e3144b37aa20e81dacc6177de1"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a9357736cb47b4a789f59f8fab9b0d10b0a9c84f9876367c398718d3de085888"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:cd08f32ea7724906ef504a0fd40a32e2a0be4d64b9239530a31767ca9ccfc921"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:5d9985b0e050cae72bf2c6a1cc8180ff4fa3a812cd63b2dc59e09c6f7f6263a1"},
+    {file = "pyobjc_framework_libdispatch-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:cfe515f4c3ea66c13fce4a527230027517b8b779b40bbcb220ff7cdf3ad20bc4"},
+    {file = "pyobjc_framework_libdispatch-11.1.tar.gz", hash = "sha256:11a704e50a0b7dbfb01552b7d686473ffa63b5254100fdb271a1fe368dd08e87"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-libxpc"
+version = "11.1"
+description = "Wrappers for xpc on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_libxpc-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:427ce45f700720198c365a099fb2f4f2fa28dbf85a7c4076371f61dbd16a0b6f"},
+    {file = "pyobjc_framework_libxpc-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4ec8a7df24d85a561fc21d0eb0db89e8cddefeedec71c69bccf17f99804068ed"},
+    {file = "pyobjc_framework_libxpc-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c29b2df8d74ff6f489afa7c39f7c848c5f3d0531a6bbe704571782ee6c820084"},
+    {file = "pyobjc_framework_libxpc-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6862e63f565823d4eeb56f18f90a3ee8682c52a8d4bcd486d3535c9959464eda"},
+    {file = "pyobjc_framework_libxpc-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2df539d11b65e229f8436a3660d0d1dce2cc7ba571054c5b91350b836db22576"},
+    {file = "pyobjc_framework_libxpc-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:4f3083fde3c366cc58bcdb2c183fae9c531fb556d35a495818019f1a5d85c24d"},
+    {file = "pyobjc_framework_libxpc-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:654db8e822e60a1246d4d55c7127a140e10d6faa0da5a7366a16cc10def44deb"},
+    {file = "pyobjc_framework_libxpc-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1648adb40fa5dabe7b49a09d8887d78c82ec11553efaa522016e98b79017704a"},
+    {file = "pyobjc_framework_libxpc-11.1.tar.gz", hash = "sha256:8fd7468aa520ff19915f6d793070b84be1498cb87224bee2bad1f01d8375273a"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-linkpresentation"
+version = "11.1"
+description = "Wrappers for the framework LinkPresentation on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_linkpresentation-11.1-py2.py3-none-any.whl", hash = "sha256:018093469d780a45d98f4e159f1ea90771caec456b1599abcc6f3bf3c6873094"},
+    {file = "pyobjc_framework_linkpresentation-11.1.tar.gz", hash = "sha256:a785f393b01fdaada6d7d6d8de46b7173babba205b13b44f1dc884b3695c2fc9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-localauthentication"
+version = "11.1"
+description = "Wrappers for the framework LocalAuthentication on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_localauthentication-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f433e611a910d89a1e327f87e2b3bd9bf33576fd8b964767487e6f278003b030"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1b6d52d07abd2240f7bc02b01ea1c630c280ed3fbc3fabe1e43b7444cfd41788"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:aa3815f936612d78e51b53beed9115c57ae2fd49500bb52c4030a35856e6569e"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9c9446c017b13c8dcadf485b76ab1d7bc12099b504bf5c2df1aae33b5dc4ab2c"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d5a2e1ea2fe8233dc244f6029d5d0c878102b2e0615cb4b81b2f30d9ee101fca"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f49c9dbbecfa0b0a7a633c60bda8179575e3685b6a696658a835c63afee90f9a"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e41be8e2132d1517e597401c7858b22531db2e7760d898993acc03ea13edb834"},
+    {file = "pyobjc_framework_localauthentication-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0e05cd69c6c5aecb26a202a6b06603bd3657a62d936ae42de93b485df667c0e6"},
+    {file = "pyobjc_framework_localauthentication-11.1.tar.gz", hash = "sha256:3cd48907c794bd414ac68b8ac595d83c7e1453b63fc2cfc2d2035b690d31eaa1"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Security = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-localauthenticationembeddedui"
+version = "11.1"
+description = "Wrappers for the framework LocalAuthenticationEmbeddedUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_localauthenticationembeddedui-11.1-py2.py3-none-any.whl", hash = "sha256:3539a947b102b41ea6e40e7c145f27280d2f36a2a9a1211de32fa675d91585eb"},
+    {file = "pyobjc_framework_localauthenticationembeddedui-11.1.tar.gz", hash = "sha256:22baf3aae606e5204e194f02bb205f244e27841ea7b4a4431303955475b4fa56"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-LocalAuthentication = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mailkit"
+version = "11.1"
+description = "Wrappers for the framework MailKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_mailkit-11.1-py2.py3-none-any.whl", hash = "sha256:8e6026462567baba194468e710e83787f29d9e8c98ea0583f7b401ea9515966e"},
+    {file = "pyobjc_framework_mailkit-11.1.tar.gz", hash = "sha256:bf97dc44cb09b9eb9d591660dc0a41f077699976144b954caa4b9f0479211fd7"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mapkit"
+version = "11.1"
+description = "Wrappers for the framework MapKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_mapkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0304816336b179a9508b6df9b7558c66e058acadf911900437db2d5b50eebecd"},
+    {file = "pyobjc_framework_mapkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:daee6bedc3acc23e62d1e7c3ab97e10425ca57e0c3cc47d2b212254705cc5c44"},
+    {file = "pyobjc_framework_mapkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:91976c6dbc8cbb020e059a0ccdeab8933184712f77164dbad5a5526c1a49599d"},
+    {file = "pyobjc_framework_mapkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b6fa1c4fffc3ae91adb965731a0cc943b3b6e82c8f21919a53a68b43a67b534"},
+    {file = "pyobjc_framework_mapkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1dc27d315849ac96647d13c82eeefce5d1d2db8c64767ce10bd3e77cbaad2291"},
+    {file = "pyobjc_framework_mapkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fb9b1d8cd5c0e8a097438369771d296de808621bc6013aa0065bc83716f5bdb0"},
+    {file = "pyobjc_framework_mapkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:fe4581f5370dc7a209c1135e9c664a5a78950d3f5c39613bfb15c1e02a6258f3"},
+    {file = "pyobjc_framework_mapkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0e4a30f6ff3a99d0adee3a1db29b90bec5f042823fbcd3a983c755e2ae5e25bb"},
+    {file = "pyobjc_framework_mapkit-11.1.tar.gz", hash = "sha256:f3a5016f266091be313a118a42c0ea4f951c399b5259d93639eb643dacc626f1"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreLocation = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mediaaccessibility"
+version = "11.1"
+description = "Wrappers for the framework MediaAccessibility on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_mediaaccessibility-11.1-py2.py3-none-any.whl", hash = "sha256:cd07e7fc375ff1e8d225e0aa2bd9c2c1497a4d3aa5a80bfb13b08800fcd7f034"},
+    {file = "pyobjc_framework_mediaaccessibility-11.1.tar.gz", hash = "sha256:52479a998fec3d079d2d4590a945fc78c41fe7ac8c76f1964c9d8156880565a4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mediaextension"
+version = "11.1"
+description = "Wrappers for the framework MediaExtension on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"24.0\""
+files = [
+    {file = "pyobjc_framework_mediaextension-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7f8a41ae51c1c70ea273f29857adc24c1d7bafc8071f0e6b50cb12b8ec5c4eb2"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:915c0cbb04913beb1f1ac8939dc0e615da8ddfba3927863a476af49f193415c5"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:06cb19004413a4b08dd75cf1e5dadea7f2df8d15feeeb7adb529d0cf947fa789"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:40f1440ccc8da6deb80810866f8c807c17567db67b53e1576ea3a3b1330c85f9"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:29edab42d9ecd394ac26f2ae2dfd7e2118452fc60a5623843919c1e9659c9dbc"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:5efd284932ed0e7cfbca90a142b84a3966c73e51308688f8c230af41f9fb8c39"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ca3a3ef1f3a759b53f297ccd701d29091eec66cc629a2b48c9acbe6c297bf256"},
+    {file = "pyobjc_framework_mediaextension-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9b410d033cb0b78b3708554189cec216b88c0b0a5c89ef586150971ff736cecc"},
+    {file = "pyobjc_framework_mediaextension-11.1.tar.gz", hash = "sha256:85a1c8a94e9175fb364c453066ef99b95752343fd113f08a3805cad56e2fa709"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-AVFoundation = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-medialibrary"
+version = "11.1"
+description = "Wrappers for the framework MediaLibrary on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_medialibrary-11.1-py2.py3-none-any.whl", hash = "sha256:779be84bd280f63837ce02028ca46b41b090902aa4205887ffd5777f49377669"},
+    {file = "pyobjc_framework_medialibrary-11.1.tar.gz", hash = "sha256:102f4326f789734b7b2dfe689abd3840ca75a76fb8058bd3e4f85398ae2ce29d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "11.1"
+description = "Wrappers for the framework MediaPlayer on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"16.0\""
+files = [
+    {file = "pyobjc_framework_mediaplayer-11.1-py2.py3-none-any.whl", hash = "sha256:b655cf537ea52d73209eb12935a047301c30239b318a366600f0f44335d51c9a"},
+    {file = "pyobjc_framework_mediaplayer-11.1.tar.gz", hash = "sha256:d07a634b98e1b9eedd82d76f35e616525da096bd341051ea74f0971e0f2f2ddd"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-AVFoundation = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mediatoolbox"
+version = "11.1"
+description = "Wrappers for the framework MediaToolbox on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c6beb3be7bb3e899b8e6e7c328c5d94e706b64f10023a49a108d74c03d132545"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:da60c0409b18dfb9fa60a60589881e1382c007700b99722926270feadcf3bfc1"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2867c91645a335ee29b47e9c0e9fd3ea8c9daad0c0719c50b8bf244d76998056"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bf26348d20caef38efb9cfc02d28af83c930b2f2c9581407f8ec04b3d8321a7a"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:975de470af8e52104bd1548eb9b4b0ef98524f35a6263c0bb4182797b9c5975b"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d781e45fb1a7e532bcbae38c0f491629eaa641cdc226019544123b51794baf34"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e30fd2ffdea1b2c7c314d07266bce7614197c2b3ffd5b09f7012e7df7aa5c7a6"},
+    {file = "pyobjc_framework_mediatoolbox-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e9efec4dc4f29aa17d6daf53377b6f375d3afc027c2cdc409b5e9f061934099c"},
+    {file = "pyobjc_framework_mediatoolbox-11.1.tar.gz", hash = "sha256:97834addc5179b3165c0d8cd74cc97ad43ed4c89547724216426348aca3b822a"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-metal"
+version = "11.1"
+description = "Wrappers for the framework Metal on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_metal-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9c77f71b7499a27f90d43a34ccd41de15c1ee8c33f9fb4293e1395d88c2aaae1"},
+    {file = "pyobjc_framework_metal-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:157a0052be459ffb35a3687f77a96ea87b42caf4cdd0b9f7245242b100edb4f0"},
+    {file = "pyobjc_framework_metal-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f3aae0f9a4192a7f4f158dbee126ab5ef63a81bf9165ec63bc50c353c8d0e6f"},
+    {file = "pyobjc_framework_metal-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d9b24d0ddb98b34a9a19755e5ca507c62fcef40ee5eae017e39be29650137f8c"},
+    {file = "pyobjc_framework_metal-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:de71b46062cb533be2c025cd6018fd4db9d7fd6a65bd67131d8e484c3616321a"},
+    {file = "pyobjc_framework_metal-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:b4c4dcab1db5750575a49a0a903528ea64b5bb93a9f3aaac5c810117a9c07e9c"},
+    {file = "pyobjc_framework_metal-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:432fefd3b27ab58c703b2f07afbc4690af815a9a8b4f8a997c4aefa8652e71d7"},
+    {file = "pyobjc_framework_metal-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:802539496ff504e5bd43b65acbe98268c5e20994e0d343e388f94ef510e16f50"},
+    {file = "pyobjc_framework_metal-11.1.tar.gz", hash = "sha256:f9fd3b7574a824632ee9b7602973da30f172d2b575dd0c0f5ef76b44cfe9f6f9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-metalfx"
+version = "11.1"
+description = "Wrappers for the framework MetalFX on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_metalfx-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fae511ea96f4ce8aff89ee71294c26294863b5a87b6665e9b4c1b47fd7ebe6ea"},
+    {file = "pyobjc_framework_metalfx-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cbfca74f437fcde89de85d14de33c2e617d3084f5fc2b4d614a700e516324f55"},
+    {file = "pyobjc_framework_metalfx-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:60e1dcdf133d2504d810c3a9ba5a02781c9d54c2112a9238de8e3ca4e8debf31"},
+    {file = "pyobjc_framework_metalfx-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fdced91f6b2012c556db954de0e17f6d7985d52b4af83262f4d083bcd87aa01c"},
+    {file = "pyobjc_framework_metalfx-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e1b2819bd6a66ba55fb7019b45d38a803ea21b8258fa41c8e9ad7c28cfe74092"},
+    {file = "pyobjc_framework_metalfx-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:aedfee1218b5784b010d618332a2cc088ba2ff9414eaa06e5db465eb5ef0aa43"},
+    {file = "pyobjc_framework_metalfx-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:934cbc969182c57f5094389fe4afe6695595757d0d61f1ab663257475fdcc593"},
+    {file = "pyobjc_framework_metalfx-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:795c365221fdc9583e7e33f4512782f8b2666f16f8a784d062b6b44007f42bda"},
+    {file = "pyobjc_framework_metalfx-11.1.tar.gz", hash = "sha256:555c1b895d4ba31be43930f45e219a5d7bb0e531d148a78b6b75b677cc588fd8"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Metal = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-metalkit"
+version = "11.1"
+description = "Wrappers for the framework MetalKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_metalkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e0be12860e68d960631bba4704b82670e4964191b5a20dbb48b4e1d840553ea9"},
+    {file = "pyobjc_framework_metalkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:95abb993d17be7a9d1174701594cc040e557983d0a0e9f49b1dfa9868ef20ed6"},
+    {file = "pyobjc_framework_metalkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4854cf74fccf6ce516b49bf7cf8fc7c22da9a3743914a2f4b00f336206ad47ec"},
+    {file = "pyobjc_framework_metalkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62e261b7798b276fee1fee065030a5d19d173863e9c697a80d1fc9a22258ec2c"},
+    {file = "pyobjc_framework_metalkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b8a378135566e3c48838c19044e17ed2598a4050516ee1c23eee7d42439ef3c8"},
+    {file = "pyobjc_framework_metalkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:ce886f3966144774d9222148eaf29fb08097d7dab5658186ded597b7c088f927"},
+    {file = "pyobjc_framework_metalkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e0776886fcd79fe7f0c55c718ebcdf073ac3e05d03040ab284ee09902fe1c70"},
+    {file = "pyobjc_framework_metalkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6325954c5aeb3ff86d664abff8f5b8238f9ff53aadba21fd801db51c72e78ecd"},
+    {file = "pyobjc_framework_metalkit-11.1.tar.gz", hash = "sha256:8811cd81ee9583b9330df4f2499a73dcc53f3359cb92767b409acaec9e4faa1e"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Metal = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshaders"
+version = "11.1"
+description = "Wrappers for the framework MetalPerformanceShaders on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"17.0\""
+files = [
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:045efaf395f7f08380a2a16cd21d75a7c295edb0311728cf37133b6c1842f1ec"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:81ec1f85c55d11529008e6a0fb1329d5184620f04d89751c11bf14d7dd9798ee"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:06b2a4e446fe859e30f7efc7ccfbaefd443225a6ec53d949a113a6a4acc16c4c"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:97be4bd0ded06c663205bd1cf821e148352346f147da48dba44cf7680f0ea23b"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c905a3f5a34a95c1fd26bf07da505ed84b9b0a0c88a8f004914d9173f5037142"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:21ca31e4246e491df788f00978744d37db975266065f7ccbf393f027b4c6e248"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:c651e62ce58e75a88cfd287357fdd8d9a7f729c87248c8f43ce16025986afe6a"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:88e0d220fae47f3f9bbafb44435e5da532cbfb936b42c694d8bfc20a0e462237"},
+    {file = "pyobjc_framework_metalperformanceshaders-11.1.tar.gz", hash = "sha256:8a312d090a0f51651e63d9001e6cc7c1aa04ceccf23b494cbf84b7fd3d122071"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Metal = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshadersgraph"
+version = "11.1"
+description = "Wrappers for the framework MetalPerformanceShadersGraph on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_metalperformanceshadersgraph-11.1-py2.py3-none-any.whl", hash = "sha256:9b8b014e8301c2ae608a25f73bbf23c8f3f73a6f5fdbafddad509a21b84df681"},
+    {file = "pyobjc_framework_metalperformanceshadersgraph-11.1.tar.gz", hash = "sha256:d25225aab4edc6f786b29fe3d9badc4f3e2d0caeab1054cd4f224258c1b6dbe2"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-MetalPerformanceShaders = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-metrickit"
+version = "11.1"
+description = "Wrappers for the framework MetricKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_metrickit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41896afbbaf6ad817b3f1c595f4c728026bf04a0e0adaafc5157b3a4d078cb76"},
+    {file = "pyobjc_framework_metrickit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a5d2b394f7acadd17d8947d188106424f59393b45dd4a842ac3cc50935170e3e"},
+    {file = "pyobjc_framework_metrickit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a034e6b982e915da881edef87d71b063e596511d52aef7a32c683571f364156e"},
+    {file = "pyobjc_framework_metrickit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95e98e96b8f122b0141e84f13ae9e0f91d09d0803b1c093fdc7d19123f000f9e"},
+    {file = "pyobjc_framework_metrickit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:14de8dcaa107fe15546df91b1f7d51dc398169c3d1b06e02291fdb8722c6bf41"},
+    {file = "pyobjc_framework_metrickit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:75c5a62abc535387eea6a1e1612cfa5b1d59512ebfa8a3352596d481b18cc714"},
+    {file = "pyobjc_framework_metrickit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:92483af233a2c31ef73dd0f7a32988a323f9560699f2f1c6c10a8a282a7b9cfd"},
+    {file = "pyobjc_framework_metrickit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:026e9bb1773452027c23dc5de50d45b09e609b317b4b45fcde9566a4fa0f3989"},
+    {file = "pyobjc_framework_metrickit-11.1.tar.gz", hash = "sha256:a79d37575489916c35840e6a07edd958be578d3be7a3d621684d028d721f0b85"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-mlcompute"
+version = "11.1"
+description = "Wrappers for the framework MLCompute on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_mlcompute-11.1-py2.py3-none-any.whl", hash = "sha256:975150725e919f8d3d33f830898f3cd2fd19a440999faab320609487f4eae19d"},
+    {file = "pyobjc_framework_mlcompute-11.1.tar.gz", hash = "sha256:f6c4c3ea6a62e4e3927abf9783c40495aa8bb9a8c89def744b0822da58c2354b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-modelio"
+version = "11.1"
+description = "Wrappers for the framework ModelIO on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_modelio-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:deb2d703f092a6f2b0b7d5044b0c3825a4c2c2f068f38bc2052a76e93f777bb0"},
+    {file = "pyobjc_framework_modelio-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4365fb96eb42b71c12efdfa2ff9d44755d5c292b8d1c78b947833d84271e359f"},
+    {file = "pyobjc_framework_modelio-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5d5e11389bde0852490b2a37896aaf9eb674b2a3586f2c572f9101cecb7bc576"},
+    {file = "pyobjc_framework_modelio-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:34fabde55d28aa8a12dd4476ad40182513cf87ee2fa928043aa6702961de302b"},
+    {file = "pyobjc_framework_modelio-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:327e1f3020001fd15bfbf4d4228581a8f64bd85872fd697b7c306343c11e25a6"},
+    {file = "pyobjc_framework_modelio-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:214a4078950bc7b86a1ea70504ecf292cccebe6515c70023efdddaaa6423f455"},
+    {file = "pyobjc_framework_modelio-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:1b1393ddb315c0e8bed3f6ce4e4b355869a30c81ff79bda3ca3a201c0fd06dad"},
+    {file = "pyobjc_framework_modelio-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d9acc1738280dfaa34bd3de6dd361200302d63b98ecec9a3d10fa888b6f067e1"},
+    {file = "pyobjc_framework_modelio-11.1.tar.gz", hash = "sha256:fad0fa2c09d468ac7e49848e144f7bbce6826f2178b3120add8960a83e5bfcb7"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-multipeerconnectivity"
+version = "11.1"
+description = "Wrappers for the framework MultipeerConnectivity on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:092fc396d235a8f3513b2ba4f8ff35fbd325d858eb9babe4df9c07d063ed647e"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b3c9d4d36e0c142b4ce91033740ed5bca19fe7ec96870d90610d2942ecd3cd39"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:970031deb3dbf8da1fcb04e785d4bd2eeedae8f6677db92881df6d92b05c31d6"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c92c95ea611d5272ab37fd73bc8e68c3d8fde515a75b97d8b22dafa8acbc7daf"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:296e10d289887cc4141c660f884cced1ec4ce64a19b3e406f13f6ce453a9425f"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:35c1a4a4b16df68b658b8531f97799995816a5bf49efd66805e3057b9bb9e474"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:c28ad5c0c6d28cbc897aaebcc5f14798762aa9fec7f9110171570fef4d8d8a36"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:04307a8c80a9fba73360ef8981c67410c4d395418478976fead05161fe12f7b1"},
+    {file = "pyobjc_framework_multipeerconnectivity-11.1.tar.gz", hash = "sha256:a3dacca5e6e2f1960dd2d1107d98399ff81ecf54a9852baa8ec8767dbfdbf54b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-naturallanguage"
+version = "11.1"
+description = "Wrappers for the framework NaturalLanguage on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"18.0\""
+files = [
+    {file = "pyobjc_framework_naturallanguage-11.1-py2.py3-none-any.whl", hash = "sha256:65a780273d2cdd12a3fa304e9c9ad822cb71facd9281f1b35a71640c53826f7c"},
+    {file = "pyobjc_framework_naturallanguage-11.1.tar.gz", hash = "sha256:ab1fc711713aa29c32719774fc623bf2d32168aed21883970d4896e901ff4b41"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-netfs"
+version = "11.1"
+description = "Wrappers for the framework NetFS on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_netfs-11.1-py2.py3-none-any.whl", hash = "sha256:f202e8e0c2e73516d3eac7a43b1c66f9911cdbb37ea32750ed197d82162c994a"},
+    {file = "pyobjc_framework_netfs-11.1.tar.gz", hash = "sha256:9c49f050c8171dc37e54d05dd12a63979c8b6b565c10f05092923a2250446f50"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-network"
+version = "11.1"
+description = "Wrappers for the framework Network on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"18.0\""
+files = [
+    {file = "pyobjc_framework_network-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:53469903051aafbdd099c57c75b825f04167f1e3889634806af2bb762081d704"},
+    {file = "pyobjc_framework_network-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e56691507584c09cdb50f1cd69b5f57b42fd55c396e8c34fab8c5b81b44d36ed"},
+    {file = "pyobjc_framework_network-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8cdc9be8ec3b0ae95e5c649e4bbcdf502cffd357dacc566223be707bdd5ac271"},
+    {file = "pyobjc_framework_network-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:04582fef567392c2a10dcee9519356b79b17ab73ded050d14592da938d95b01a"},
+    {file = "pyobjc_framework_network-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:acf16738ab447a31a9f6167171b2a00d65a9370a8e84482d435b2b31c58eed94"},
+    {file = "pyobjc_framework_network-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:cafdf953aa80934d30726baa681c1af61daf2cc9fe9e3ca582f4e3796bd0d053"},
+    {file = "pyobjc_framework_network-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:2e45d8fdc0ad553cc35839cae5eab221fe5f7ce28758d693b8159e619ea06eac"},
+    {file = "pyobjc_framework_network-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:141383b2eb048ff3d70ca94fe045d0d9cba896856f74e18f0639b84ae6b3ff07"},
+    {file = "pyobjc_framework_network-11.1.tar.gz", hash = "sha256:f6df7a58a1279bbc976fd7e2efe813afbbb18427df40463e6e2ee28fba07d2df"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-networkextension"
+version = "11.1"
+description = "Wrappers for the framework NetworkExtension on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_networkextension-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7a679a2b17038de2fc3d66fce68361fb8152bd4e18cf95c15ccdbdef83d9da74"},
+    {file = "pyobjc_framework_networkextension-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:55e5ca70c81a864896b603cfcabf4c065783f64395460d16fe16db2bf0866d60"},
+    {file = "pyobjc_framework_networkextension-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:853458aae8b43634461f6c44759750e2dc784c9aba561f9468ab14529b5a7fbe"},
+    {file = "pyobjc_framework_networkextension-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d3d6e9810cb01c3a8f99aed5ee2d75f6f785204338b99b32e5f64370a18cc9dd"},
+    {file = "pyobjc_framework_networkextension-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7dea914e7b26e28c6e4f8ffd03dd8fce612d38876043944fb0cf191774634566"},
+    {file = "pyobjc_framework_networkextension-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:4c9d6c08b8f1cf374351bcecf8bbc91e6a8999b84d52f30964f4f1e6a323943c"},
+    {file = "pyobjc_framework_networkextension-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:6d730540d97662867f3cfd90c9a1e69a6adae0f5eb554c1b94a1b067e7ebc728"},
+    {file = "pyobjc_framework_networkextension-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:77226fd8bc78b65e3adbdce32d2838cd819f2b570fbe845b895cff6ca1e7bd44"},
+    {file = "pyobjc_framework_networkextension-11.1.tar.gz", hash = "sha256:2b74b430ca651293e5aa90a1e7571b200d0acbf42803af87306ac8a1c70b0d4b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-notificationcenter"
+version = "11.1"
+description = "Wrappers for the framework NotificationCenter on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"14.0\""
+files = [
+    {file = "pyobjc_framework_notificationcenter-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:70704ba076eb30a2e25fd9d738d4ed2cf4a684c87a9129b1fc0c570301f53eee"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3d44413818e7fa3662f784cdcf0730c86676dd7333b7d24a7da13d4ffcde491b"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:65fc67374a471890245c7a1d60cf67dcf160075a9c048a5d89608a8290f33b03"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f5ce98882e301adef07651ba495ddd57b661d4c0398afd39f4591c1b44673cca"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e46285290d04e84c167606ccfcb9a20c2567f5a2a6a9c6e96760fc9d561c2740"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c3e79e9c57f130099b47bde48f26fcd90ab3b52e01d989ea15b7cdb7fa5a34d8"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:15e49491d7f091eaa643f2fd89787becbf767dd6c609aa3d01e53132cb1d9fa1"},
+    {file = "pyobjc_framework_notificationcenter-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bbb96dfca9f93b0f9a9de2c4a2c87128b60d6365bf79121e08bebd35c20685f5"},
+    {file = "pyobjc_framework_notificationcenter-11.1.tar.gz", hash = "sha256:0b938053f2d6b1cea9db79313639d7eb9ddd5b2a5436a346be0887e75101e717"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-opendirectory"
+version = "11.1"
+description = "Wrappers for the framework OpenDirectory on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_opendirectory-11.1-py2.py3-none-any.whl", hash = "sha256:bb4219b0d98dff4a952c50a79b1855ce74e1defd0d241f3013def5b09256fd7b"},
+    {file = "pyobjc_framework_opendirectory-11.1.tar.gz", hash = "sha256:319ac3424ed0350be458b78148914468a8fc13a069d62e7869e3079108e4f118"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-osakit"
+version = "11.1"
+description = "Wrappers for the framework OSAKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_osakit-11.1-py2.py3-none-any.whl", hash = "sha256:1b0c0cc537ffb8a8365ef9a8b46f717a7cc2906414b6a3983777a6c0e4d53d5a"},
+    {file = "pyobjc_framework_osakit-11.1.tar.gz", hash = "sha256:920987da78b67578367c315d208f87e8fab01dd35825d72242909f29fb43c820"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-oslog"
+version = "11.1"
+description = "Wrappers for the framework OSLog on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_oslog-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d064b4ed8960bb65a277af16938043ebb4fb1d38fd47129bc9b9aeb6d385d4bc"},
+    {file = "pyobjc_framework_oslog-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5dab25ef1cde4237cd2957c1f61c2888968e924304f7b9d9699eceeb330e9817"},
+    {file = "pyobjc_framework_oslog-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7ae29c31ce51c476d3a37ca303465dd8bdfa98df2f6f951cf14c497e984a1ba9"},
+    {file = "pyobjc_framework_oslog-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7174ca2cdc073e555d5f5aea3baa7410c61a83a3741eaec23e8581340037680e"},
+    {file = "pyobjc_framework_oslog-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f03789f8d5638e1075652b331b8ebf98c03dfa809c57545f0313583a7688bb86"},
+    {file = "pyobjc_framework_oslog-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a302272aa40d1655be635e0f0dd0ca71b5fce562dfcb88a87165a170a648b2fd"},
+    {file = "pyobjc_framework_oslog-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:cade8869e185a29fb88fc48e2e5c984548433f669c1a40ec7f5640994fa36603"},
+    {file = "pyobjc_framework_oslog-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2563e1e5a83f47cb62545e014c8b407dc7130c0c21a897c21db8593a8d130e09"},
+    {file = "pyobjc_framework_oslog-11.1.tar.gz", hash = "sha256:b2af409617e6b68fa1f1467c5a5679ebf59afd0cdc4b4528e1616059959a7979"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-passkit"
+version = "11.1"
+description = "Wrappers for the framework PassKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_passkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9f195a9c7d0ad46c975d22a0e3362ea6ccdb01e4cb1f81221db1037aee8225ff"},
+    {file = "pyobjc_framework_passkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:67b7b1ee9454919c073c2cba7bdba444a766a4e1dd15a5e906f4fa0c61525347"},
+    {file = "pyobjc_framework_passkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:779eaea4e1931cfda4c8701e1111307b14bf9067b359a319fc992b6848a86932"},
+    {file = "pyobjc_framework_passkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a6306dda724ca812dca70154d40f32ec9bbdaff765a12f3cc45391723efe147e"},
+    {file = "pyobjc_framework_passkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d7948d5b3369b60808a85dcadffdebb0a44e8d2c4716edc10b78cb76fa762070"},
+    {file = "pyobjc_framework_passkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bfff2a63850afe702ba25f661360393389ffb58e127d47488c414caa9e676aa7"},
+    {file = "pyobjc_framework_passkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:f6b7f3cd7c6855af1b6fc4036ae2f10779a312182107c94d36ef63c2dd4a6f87"},
+    {file = "pyobjc_framework_passkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b75997fc26df9e9e5a664679ab5c0b6b52d0b88fb1e9b3fa5970f0bfaf121189"},
+    {file = "pyobjc_framework_passkit-11.1.tar.gz", hash = "sha256:d2408b58960fca66607b483353c1ffbd751ef0bef394a1853ec414a34029566f"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-pencilkit"
+version = "11.1"
+description = "Wrappers for the framework PencilKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_pencilkit-11.1-py2.py3-none-any.whl", hash = "sha256:b7824907bbcf28812f588dda730e78f662313baf40befd485c6f2fcb49018019"},
+    {file = "pyobjc_framework_pencilkit-11.1.tar.gz", hash = "sha256:9c173e0fe70179feadc3558de113a8baad61b584fe70789b263af202bfa4c6be"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-phase"
+version = "11.1"
+description = "Wrappers for the framework PHASE on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_phase-11.1-py2.py3-none-any.whl", hash = "sha256:cfa61f9c6c004161913946501538258aed48c448b886adbf9ed035957d93fa15"},
+    {file = "pyobjc_framework_phase-11.1.tar.gz", hash = "sha256:a940d81ac5c393ae3da94144cf40af33932e0a9731244e2cfd5c9c8eb851e3fc"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-AVFoundation = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-photos"
+version = "11.1"
+description = "Wrappers for the framework Photos on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_photos-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1cd54a6b60a7ad2f810c02ec2c4d676feec4a25d08c9328ff839034b29c15bf7"},
+    {file = "pyobjc_framework_photos-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:959dfc82f20513366b85cd37d8541bb0a6ab4f3bfa2f8094e9758a5245032d67"},
+    {file = "pyobjc_framework_photos-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8dbfffd29cfa63a8396ede0030785c15a5bc36065d3dd98fc6176a59e7abb3d3"},
+    {file = "pyobjc_framework_photos-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:541d8fafdb2f111f2f298e1aa0542f2d5871ce1dd481c3e9be4ed33916b38c3a"},
+    {file = "pyobjc_framework_photos-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7cded282eaebd77645a4262f6fb63379c7a226d20f8f1763910b19927709aea2"},
+    {file = "pyobjc_framework_photos-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3a759ebcf46493cd09e5c89c0a09096ad83ae837d9236e437571bb22ca6eab3f"},
+    {file = "pyobjc_framework_photos-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:72e0ed9bc5f1890f882df55333797da95c0ed1c1d7a0fe7d869a8d4ee4e1bdfd"},
+    {file = "pyobjc_framework_photos-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f6f044e52bfb0861a6ead5436383b5a24729d6d1be5fe9cdec5efa0ac82afe51"},
+    {file = "pyobjc_framework_photos-11.1.tar.gz", hash = "sha256:c8c3b25b14a2305047f72c7c081ff3655b3d051f7ed531476c03246798f8156d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-photosui"
+version = "11.1"
+description = "Wrappers for the framework PhotosUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"15.0\""
+files = [
+    {file = "pyobjc_framework_photosui-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c2648031c62c30089ac8170a63ffbe92e6469447a488590504edd94cd51fd45a"},
+    {file = "pyobjc_framework_photosui-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d93722aeb8c134569035fd7e6632d0247e1bcb18c3cc4e0a288664218f241b85"},
+    {file = "pyobjc_framework_photosui-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b2f278f569dfd596a32468351411518a651d12cb91e60620094e852c525a5f10"},
+    {file = "pyobjc_framework_photosui-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6f0fa9c9e363c0db54957dfe4e26214379f2698caaba1e4ff4c9e3eba5e690d9"},
+    {file = "pyobjc_framework_photosui-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:91aff7caae16a7a7f25e35692aa92b796155510b8a0575668e75f351fbf63a68"},
+    {file = "pyobjc_framework_photosui-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:e607242e09fb7d4bcad2f3eb2e88529d8f2ff7cf7341cd2c6c5b3f4d6744218e"},
+    {file = "pyobjc_framework_photosui-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:f11f6043c83b2c65ecad69c48844fff6368127af3956ec8df9726bbd1e5da17e"},
+    {file = "pyobjc_framework_photosui-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2d92550a2bcd4491a8d4c9b345f4be49abff3e2e8eb3eaf75f2764b38e970488"},
+    {file = "pyobjc_framework_photosui-11.1.tar.gz", hash = "sha256:1c7ffab4860ce3e2b50feeed4f1d84488a9e38546db0bec09484d8d141c650df"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-preferencepanes"
+version = "11.1"
+description = "Wrappers for the framework PreferencePanes on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_preferencepanes-11.1-py2.py3-none-any.whl", hash = "sha256:6ee5f5a7eb294e03ea3bac522ac4b69e6dc83ceceff627a0a2d289afe1e01ad9"},
+    {file = "pyobjc_framework_preferencepanes-11.1.tar.gz", hash = "sha256:6e4a55195ec9fc921e0eaad6b3038d0ab91f0bb2f39206aa6fccd24b14a0f1d8"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-pubsub"
+version = "11.1"
+description = "Wrappers for the framework PubSub on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "platform_release >= \"9.0\" and platform_release < \"18.0\" and sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_pubsub-11.1-py2.py3-none-any.whl", hash = "sha256:cea6bd9e0af46f9ea1c8d002a92e462576dd5a772a7e0688d40c7903755af11f"},
+    {file = "pyobjc_framework_pubsub-11.1.tar.gz", hash = "sha256:47221f63466c523516ab5d2297dd3c644d915a77ca1f1867b0055d735486f1f8"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-pushkit"
+version = "11.1"
+description = "Wrappers for the framework PushKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_pushkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:48c38a7d3bef449c23aa799b70283586e0b7d9203cf17b0666bc61278b663ed2"},
+    {file = "pyobjc_framework_pushkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5e2f08b667035df6b11a0a26f038610df1eebbedf9f3f111c241b5afaaf7c5fd"},
+    {file = "pyobjc_framework_pushkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:21993b7e9127b05575a954faa68e85301c6a4c04e34e38aff9050f67a05c562a"},
+    {file = "pyobjc_framework_pushkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bac3ee77dfbe936998f207c1579e346993485bab8849db537ed250261cf12ab3"},
+    {file = "pyobjc_framework_pushkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:68c4f44354eab84cb54d43310fa65ca3a5ba68299c868378764cc50803cf2adc"},
+    {file = "pyobjc_framework_pushkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:cfec36cdca24654be0465282eb31b7ff3674ea4b7f3ce696b07edbe33b000aa5"},
+    {file = "pyobjc_framework_pushkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:80d5d8240b71631d81cfa96f398fae1d137be98f224739e50edaf9e5afc21a9d"},
+    {file = "pyobjc_framework_pushkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:76c074efd1a6f977a4fb998786ec319a26e406e7efff1c2a14f6be89665d291a"},
+    {file = "pyobjc_framework_pushkit-11.1.tar.gz", hash = "sha256:540769a4aadc3c9f08beca8496fe305372501eb28fdbca078db904a07b8e10f4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "11.1"
+description = "Wrappers for the Quartz frameworks on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_quartz-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b5ef75c416b0209e25b2eb07a27bd7eedf14a8c6b2f968711969d45ceceb0f84"},
+    {file = "pyobjc_framework_quartz-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2d501fe95ef15d8acf587cb7dc4ab4be3c5a84e2252017da8dbb7df1bbe7a72a"},
+    {file = "pyobjc_framework_quartz-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ac806067541917d6119b98d90390a6944e7d9bd737f5c0a79884202327c9204"},
+    {file = "pyobjc_framework_quartz-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:43a1138280571bbf44df27a7eef519184b5c4183a588598ebaaeb887b9e73e76"},
+    {file = "pyobjc_framework_quartz-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b23d81c30c564adf6336e00b357f355b35aad10075dd7e837cfd52a9912863e5"},
+    {file = "pyobjc_framework_quartz-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:07cbda78b4a8fcf3a2d96e047a2ff01f44e3e1820f46f0f4b3b6d77ff6ece07c"},
+    {file = "pyobjc_framework_quartz-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:39d02a3df4b5e3eee1e0da0fb150259476910d2a9aa638ab94153c24317a9561"},
+    {file = "pyobjc_framework_quartz-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9b1f451ddb5243d8d6316af55f240a02b0fffbfe165bff325628bf73f3df7f44"},
+    {file = "pyobjc_framework_quartz-11.1.tar.gz", hash = "sha256:a57f35ccfc22ad48c87c5932818e583777ff7276605fef6afad0ac0741169f75"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-quicklookthumbnailing"
+version = "11.1"
+description = "Wrappers for the framework QuickLookThumbnailing on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_quicklookthumbnailing-11.1-py2.py3-none-any.whl", hash = "sha256:4d1863c6c83c2a199c1dbe704b4f8b71287168f4090ed218d37dc59277f0d9c9"},
+    {file = "pyobjc_framework_quicklookthumbnailing-11.1.tar.gz", hash = "sha256:1614dc108c1d45bbf899ea84b8691288a5b1d25f2d6f0c57dfffa962b7a478c3"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-replaykit"
+version = "11.1"
+description = "Wrappers for the framework ReplayKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_replaykit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:634b18c7b0f2ea548421307d6c59339d69094dfde9b638ce0ca3d6d3016de470"},
+    {file = "pyobjc_framework_replaykit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4d88c3867349865d8a3a06ea064f15aed7e5be20d22882ac8a647d9b6959594e"},
+    {file = "pyobjc_framework_replaykit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:22c6d09be9a6e758426d723a6c3658ad6bbb66f97ba9a1909bfcf29a91d99921"},
+    {file = "pyobjc_framework_replaykit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7742ee18c8c9b61f5668698a05b88d25d34461fcdd95a8f669ecdfd8db8c4d42"},
+    {file = "pyobjc_framework_replaykit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b503fabc33ee02117fd82c78db18cba3f0be90dea652f5553101a45185100402"},
+    {file = "pyobjc_framework_replaykit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:da84e48ba5d529ae72b975f0d81c5bd5427983c2b05d3d2c7fd54a6cbdf0d0f9"},
+    {file = "pyobjc_framework_replaykit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:2bf2180feae500fdd6f14360200fda0b6650a4ec39fe5d84a5dde9e8cdd307b6"},
+    {file = "pyobjc_framework_replaykit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4632ad736a746b7e1caadabd657200253383204beddb77609c207a788d4edbe5"},
+    {file = "pyobjc_framework_replaykit-11.1.tar.gz", hash = "sha256:6919baa123a6d8aad769769fcff87369e13ee7bae11b955a8185a406a651061b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-safariservices"
+version = "11.1"
+description = "Wrappers for the framework SafariServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"16.0\""
+files = [
+    {file = "pyobjc_framework_safariservices-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62e70805477b04d1abc6dfa1f22d2ee41af8a5784fa98d3dcbd9fca00b6dd521"},
+    {file = "pyobjc_framework_safariservices-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a441a2e99f7d6475bea00c3d53de924143b8f90052be226aee16f1f6d9cfdc8c"},
+    {file = "pyobjc_framework_safariservices-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c92eb9e35f98368ea1bfaa8cdd41138ca8b004ea5a85833390a44e5626ca5061"},
+    {file = "pyobjc_framework_safariservices-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8b4d4169dd21e69246d90a42f872b7148064b63de6bbbf6bc6ddabe33f143843"},
+    {file = "pyobjc_framework_safariservices-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8a4371d64052a3ffe9993a89c45f9731f86e7b6c21fd1d968815fd7930ff501a"},
+    {file = "pyobjc_framework_safariservices-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:abdbe0d8a79caa994a1d2be8ea4e5a1e4c80f7d8e1f0750f9c365129d1f1a968"},
+    {file = "pyobjc_framework_safariservices-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:8a6ec417d35a0600629eba97c0ab2f2d09fae171e8bca3d3d6aa1c7ff272c4d7"},
+    {file = "pyobjc_framework_safariservices-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3c04a8ec1cc99f93b83d59abe451b80cb137c8106e54d37aa722064b83f8d60c"},
+    {file = "pyobjc_framework_safariservices-11.1.tar.gz", hash = "sha256:39a17df1a8e1c339457f3acbff0dc0eae4681d158f9d783a11995cf484aa9cd0"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-safetykit"
+version = "11.1"
+description = "Wrappers for the framework SafetyKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_safetykit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:45c1fb59246ca9eef99149f3b325491a1aec7f775dd136f6de86aa69911cc43f"},
+    {file = "pyobjc_framework_safetykit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3333e8e53a1e8c8133936684813a2254e5d1b4fe313333a3d0273e31b9158cf7"},
+    {file = "pyobjc_framework_safetykit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b76fccdb970d3d751a540c47712e9110afac9abea952cb9b7bc0d5867db896e3"},
+    {file = "pyobjc_framework_safetykit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8130de57f701dbccb1d84c76ec007fe04992da58cbf0eb906324393eeac3d08d"},
+    {file = "pyobjc_framework_safetykit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:cd8091c902037eac4a403d8462424afd711f43206af3548a34bebe1f59d2c340"},
+    {file = "pyobjc_framework_safetykit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:761304365978d650015fe05fb624ba13ea4af6c6a76ef8e344673f5b0fed2e92"},
+    {file = "pyobjc_framework_safetykit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:24d5ce9dfb80abb634a95ceda3da0f0cdb52c765db0f47de953a4f66b918c957"},
+    {file = "pyobjc_framework_safetykit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3c286694968b5f0aea1e80c27c0ddbf3714ae0e754007619e4ffbb172b20539c"},
+    {file = "pyobjc_framework_safetykit-11.1.tar.gz", hash = "sha256:c6b44e0cf69e27584ac3ef3d8b771d19a7c2ccd9c6de4138d091358e036322d4"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-scenekit"
+version = "11.1"
+description = "Wrappers for the framework SceneKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"11.0\""
+files = [
+    {file = "pyobjc_framework_scenekit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c828200919573e1c5a02f8702b2e0f8a6c46edddd2d690666d8cf16575f4578"},
+    {file = "pyobjc_framework_scenekit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3e777dacb563946ad0c2351e6cfe3f16b8587a65772ec0654e2be9f75764d234"},
+    {file = "pyobjc_framework_scenekit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c803d95b30c4ce49f46ff7174806f5eb84e4c3a152f8f580c5da0313c5c67041"},
+    {file = "pyobjc_framework_scenekit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f347d5ae42af8acddb86a45f965046bb91f8d83d33851390954439961e2a7b7"},
+    {file = "pyobjc_framework_scenekit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ea2f02eea982872994d7c366f6a51060a90cc17b994c017f85c094e2bc346847"},
+    {file = "pyobjc_framework_scenekit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:2be143172b43c2cf4a2b3fad9e15ffb5d29df677d3678160cd125b94a30caaca"},
+    {file = "pyobjc_framework_scenekit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3f62f2b8f26375ecfec71f7fdb23f2739cf93d213968c6ffac6a8525516ffc6e"},
+    {file = "pyobjc_framework_scenekit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:032bc9f4a2cabb49617a1a23408ccab833abc404e6611c372de8ed345439aac0"},
+    {file = "pyobjc_framework_scenekit-11.1.tar.gz", hash = "sha256:82941f1e5040114d6e2c9fd35507244e102ef561c637686091b71a7ad0f31306"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-screencapturekit"
+version = "11.1"
+description = "Wrappers for the framework ScreenCaptureKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.4\""
+files = [
+    {file = "pyobjc_framework_screencapturekit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11de78f270d405bd14b784b15d4bb04a13b3d25613abd5f9aaaf2b8ef108dc60"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7203108d28d7373501c455cd4a8bbcd2eb7849906dbc7859ac17a350b141553c"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:641fa7834f54558859209e174c83551d5fa239ca6943ace52665f7d45e562ff2"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1119d6258d6c668564ab39154cfc745fd2bb8b3beeaa4f9b2a8a4c93926678c0"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f93f8198741bd904d423a7b1ef941445246bdf6cb119597d981e61a13cc479a4"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:9e135b414d3829fcf7fd8a66c94e8b51135fb9f630c10488fb9d78f27f622906"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:9972db69064b69e78fbc6a00f1de2d8eaa225b990b23687970328b061e60e26d"},
+    {file = "pyobjc_framework_screencapturekit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98412a02e7eed9199ccf1e64f6effc1a77194e2f2a38f2927d4228c5739531ac"},
+    {file = "pyobjc_framework_screencapturekit-11.1.tar.gz", hash = "sha256:11443781a30ed446f2d892c9e6642ca4897eb45f1a1411136ca584997fa739e0"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-screensaver"
+version = "11.1"
+description = "Wrappers for the framework ScreenSaver on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_screensaver-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:656651d0b6870bffeea01b65f4748936603a62dbbdc8e7a61c125ea6ebf8299c"},
+    {file = "pyobjc_framework_screensaver-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8b959761fddf06d9fb3fed6cd0cea6009d60473317e11490f66dcf0444011d5f"},
+    {file = "pyobjc_framework_screensaver-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f2d22293cf9d715e4692267a1678096afd6793c0519d9417cf77c8a6c706a543"},
+    {file = "pyobjc_framework_screensaver-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:46d65c1e14d35f287e7be351e2f98daf9489e31e7ca0d306e6102904ce6c40fb"},
+    {file = "pyobjc_framework_screensaver-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2c01a9646bc118445cbb117e7016bd1df9fe93a65db991ab5496d59b1a7bc66d"},
+    {file = "pyobjc_framework_screensaver-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:e32c83e1d9e5044d482916ac42257a87d1f1068f3f6bccaa04edda40fb9f9ad1"},
+    {file = "pyobjc_framework_screensaver-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:7852c2281148cb99c87c4c25b83dca7fdd11e6eed04deadcf2201ed5a2079e5f"},
+    {file = "pyobjc_framework_screensaver-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a3cd83eda8a85c02a852cdd5d79f92e8850dcbe9f80de1f66fd0e5eaed7afbba"},
+    {file = "pyobjc_framework_screensaver-11.1.tar.gz", hash = "sha256:d5fbc9dc076cc574ead183d521840b56be0c160415e43cb8e01cfddd6d6372c2"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-screentime"
+version = "11.1"
+description = "Wrappers for the framework ScreenTime on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_screentime-11.1-py2.py3-none-any.whl", hash = "sha256:50a4e4ab33d6643a52616e990aa1c697d5e3e8f9f9bdab8d631e6d42d8287b4f"},
+    {file = "pyobjc_framework_screentime-11.1.tar.gz", hash = "sha256:9bb8269456bbb674e1421182efe49f9168ceefd4e7c497047c7bf63e2f510a34"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-scriptingbridge"
+version = "11.1"
+description = "Wrappers for the framework ScriptingBridge on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"9.0\""
+files = [
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2cf247dfe9f98aa3c8210395d045a708a4133a5d6164673213eb39afc4f6dd31"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6020c69c14872105852ff99aab7cd2b2671e61ded3faefb071dc40a8916c527"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:226ba12d9cbd504411b702323b0507dd1690e81b4ce657c5f0d8b998c46cf374"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c2ba0ad3d3e4e3c6a43fe3e84ab02c5c4e74000bb6f130ae47bf82a3dcd4af98"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:57f5401826e3a008d9cfb7c164187859cadc1b1f96194dc0a7c596f502548c26"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a84d0a8ff4fa1f0016f5d797ad93e22e437212a2fc8e6417a3b8d68f89229680"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:5381e9be1299e1134489e4d46662c649613214265b3b691264cfba0b083929f5"},
+    {file = "pyobjc_framework_scriptingbridge-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1d12f1b9de8d862fa8e215e6b8181455f0624cd5d50f8ab4f0cc014b52c2649d"},
+    {file = "pyobjc_framework_scriptingbridge-11.1.tar.gz", hash = "sha256:604445c759210a35d86d3e0dfcde0aac8e5e3e9d9e35759e0723952138843699"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-searchkit"
+version = "11.1"
+description = "Wrappers for the framework SearchKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_searchkit-11.1-py2.py3-none-any.whl", hash = "sha256:9c9d6ca71cef637ccc3627225fb924a460b3d0618ed79bb0b3c12fcbe9270323"},
+    {file = "pyobjc_framework_searchkit-11.1.tar.gz", hash = "sha256:13a194eefcf1359ce9972cd92f2aadddf103f3efb1b18fd578ba5367dff3c10c"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-CoreServices = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "11.1"
+description = "Wrappers for the framework Security on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_security-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ffe21933b554098709087fbc4e629ab4875e75d74ffb741de508063dba56c73e"},
+    {file = "pyobjc_framework_security-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d361231697486e97cfdafadf56709190696ab26a6a086dbba5f170e042e13daa"},
+    {file = "pyobjc_framework_security-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2eb4ba6d8b221b9ad5d010e026247e8aa26ee43dcaf327e848340ed227d22d7e"},
+    {file = "pyobjc_framework_security-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:158da3b2474e2567fd269531c4ee9f35b8ba4f1eccbd1fb4a37c85a18bf1243c"},
+    {file = "pyobjc_framework_security-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:141cc3ee08627ae0698264efc3dbbaf28d2255e0fe690e336eb8f0f387c4af01"},
+    {file = "pyobjc_framework_security-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:858a18303711eb69d18d1a64cf8bb2202f64a3bd1c82203c511990dbd8326514"},
+    {file = "pyobjc_framework_security-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:4db1ebf6395cd370139cb35ff172505fc449c7fdf5d3a28f2ada8a30ef132cd0"},
+    {file = "pyobjc_framework_security-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5dec8412602256e1d7039e670fb987bf1b233a55086e1204f1e32d7aab798f98"},
+    {file = "pyobjc_framework_security-11.1.tar.gz", hash = "sha256:dabcee6987c6bae575e2d1ef0fcbe437678c4f49f1c25a4b131a5e960f31a2da"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-securityfoundation"
+version = "11.1"
+description = "Wrappers for the framework SecurityFoundation on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_securityfoundation-11.1-py2.py3-none-any.whl", hash = "sha256:25f2cf10f80c122f462e9d4d43efe9fd697299c194e0c357e76650e234e6d286"},
+    {file = "pyobjc_framework_securityfoundation-11.1.tar.gz", hash = "sha256:b3c4cf70735a93e9df40f3a14478143959c415778f27be8c0dc9ae0c5b696b92"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Security = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-securityinterface"
+version = "11.1"
+description = "Wrappers for the framework SecurityInterface on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_securityinterface-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:127da21b8fd4d8df0f1d680f581cef714eeb8c2db31e72b2c5395e2ad41936ff"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3e884620b22918d462764f0665f6ac0cbb8142bb160fcd27c4f4357f81da73b7"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:26056441b325029da06a7c7b8dd1a0c9a4ad7d980596c1b04d132a502b4cacc0"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:708dd1d65309f3d4043ecaf152591c240601a5d3da7ae7a500f511c54317537b"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e9ebfb32177eb06f5c894be97c6af3802f09b9890fce8e0956cc0e680af4eafd"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:0232f947b4f906097a5d758305097a8688835a52e0721b75ae3f1180eac30f50"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:2c20bedead75de7bf1f2ceda562755f64c70ee86180ed45480dc9dbc55609a0b"},
+    {file = "pyobjc_framework_securityinterface-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d5493ebf2d62458485b4461a16fb9756de31c1e4be34daa4d539239adf25132c"},
+    {file = "pyobjc_framework_securityinterface-11.1.tar.gz", hash = "sha256:e7aa6373e525f3ae05d71276e821a6348c53fec9f812b90eec1dbadfcb507bc9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Security = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-securityui"
+version = "11.1"
+description = "Wrappers for the framework SecurityUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"24.4\""
+files = [
+    {file = "pyobjc_framework_securityui-11.1-py2.py3-none-any.whl", hash = "sha256:3cdb101b03459fcf8e4064b90021d06761003f669181e02f43ff585e6ba2403d"},
+    {file = "pyobjc_framework_securityui-11.1.tar.gz", hash = "sha256:e80c93e8a56bf89e4c0333047b9f8219752dd6de290681e9e2e2b2e26d69e92d"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Security = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-sensitivecontentanalysis"
+version = "11.1"
+description = "Wrappers for the framework SensitiveContentAnalysis on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"23.0\""
+files = [
+    {file = "pyobjc_framework_sensitivecontentanalysis-11.1-py2.py3-none-any.whl", hash = "sha256:dbb78f5917f986a63878bb91263bceba28bd86fc381bad9461cf391646db369f"},
+    {file = "pyobjc_framework_sensitivecontentanalysis-11.1.tar.gz", hash = "sha256:5b310515c7386f7afaf13e4632d7d9590688182bb7b563f8026c304bdf317308"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-servicemanagement"
+version = "11.1"
+description = "Wrappers for the framework ServiceManagement on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"10.0\""
+files = [
+    {file = "pyobjc_framework_servicemanagement-11.1-py2.py3-none-any.whl", hash = "sha256:104f56557342a05ad68cd0c9daf63b7f4678957fe1f919f03a872f1607a50710"},
+    {file = "pyobjc_framework_servicemanagement-11.1.tar.gz", hash = "sha256:90a07164da49338480e0e135b445acc6ae7c08549a2037d1e512d2605fedd80a"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-sharedwithyou"
+version = "11.1"
+description = "Wrappers for the framework SharedWithYou on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2a218b3c89253a5c3a0ca974854872b68f58d46373a3e38ab20a82c9484a1062"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ce1c37d5f8cf5b0fe8a261e4e7256da677162fd5aa7b724e83532cdfe58d8f94"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:99e1749187ae370be7b9c55dd076d1b8143f0d8db3e83f52540586f32e7abb33"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c1a1770aa2c417f17010623414fb12943570baa726d8780dd7446ba5bcee8c3d"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:63b1cb673b844ebfeddc032d0539f913bbd6b67ab2a310a1fcff7842dba9c714"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:481362f0bde6def86634fc687abe6f4dee650c09c22b48bfe5af5322f9947cef"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:70421a8fd326afd99eeae273b693a7b4d2d200c38e883d8219a84123a4ba0861"},
+    {file = "pyobjc_framework_sharedwithyou-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ac08df8e62ad348d0fae889731eb18379a49e891ed0b19d1bbddef7af0284df"},
+    {file = "pyobjc_framework_sharedwithyou-11.1.tar.gz", hash = "sha256:ece3a28a3083d0bcad0ac95b01f0eb699b9d2d0c02c61305bfd402678753ff6e"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-SharedWithYouCore = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-sharedwithyoucore"
+version = "11.1"
+description = "Wrappers for the framework SharedWithYouCore on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:daa8de2cbf5ec8e768e4d8b7b7cd410747d92ca83ccf7d114563537448099136"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9a7fe5ffcc65093ef7cd25903769ad557c3d3c5a59155a31f3f934cf555101e6"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dd18c588b29de322c25821934d6aa6d2bbbdbb89b6a4efacdb248b4115fc488d"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a3fb0e745fd022fed48cc9a5e0dcbf8d1abcb5bfc192150e3a2584f4351791fc"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6aee3df8bed97a74e1f79609f9884edcaab2d305db20bdcae39e47b3e513c559"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:5a45c562c99017f8e057d4080012b63a9bb660c696334707c54d7b4018ca1017"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:4e19bfc74f392546ca4b7ea5271d4802617445ad493428370eafd3cddd4d977e"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:cbb6ed02c8c38e2cdca0fb2c710374fc5cda13d2be40f3d002f1f852006e64ca"},
+    {file = "pyobjc_framework_sharedwithyoucore-11.1.tar.gz", hash = "sha256:790050d25f47bda662a9f008b17ca640ac2460f2559a56b17995e53f2f44ed73"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-shazamkit"
+version = "11.1"
+description = "Wrappers for the framework ShazamKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"21.0\""
+files = [
+    {file = "pyobjc_framework_shazamkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5f19e1f307d84c53271af7ed70a3c39f134a46e358672fb8c74ced7205949551"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2fe6990d0ec1b40d4efd0d0e49c2deb65198f49b963e6215c608c140b3149151"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b323f5409b01711aa2b6e2113306084fab2cc83fa57a0c3d55bd5876358b68d8"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bac17f285742e0f13a54c7085ef3035d8034ffc43d18d3d68fb41283c5064ff"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b3304c3a67e3722b895d874f215dd4277b49cedddb72fa780a791ef79e5c3d45"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:ef51f461672234076b3791ad4be05adad20a2e24b9d7d93acd7bf18d7f9b1714"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:f7d191fb187dbb05e3f88f546d5207618d65e270d7a4316b51b1171cc491e268"},
+    {file = "pyobjc_framework_shazamkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:00a65ae3ba449ba19144b6acb093afd9ddeae67b69828928ca536174f0e8dec2"},
+    {file = "pyobjc_framework_shazamkit-11.1.tar.gz", hash = "sha256:c6e3c9ab8744d9319a89b78ae6f185bb5704efb68509e66d77bcd1f84a9446d6"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-social"
+version = "11.1"
+description = "Wrappers for the framework Social on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_social-11.1-py2.py3-none-any.whl", hash = "sha256:ab5878c47d7a0639704c191cee43eeb259e09688808f0905c42551b9f79e1d57"},
+    {file = "pyobjc_framework_social-11.1.tar.gz", hash = "sha256:fbc09d7b00dad45b547f9b2329f4dcee3f5a50e2348de1870de0bd7be853a5b7"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-soundanalysis"
+version = "11.1"
+description = "Wrappers for the framework SoundAnalysis on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_soundanalysis-11.1-py2.py3-none-any.whl", hash = "sha256:6cf983c24fb2ad2aa5e7499ab2d30ff134d887fe91fd2641acf7472e546ab4e5"},
+    {file = "pyobjc_framework_soundanalysis-11.1.tar.gz", hash = "sha256:42cd25b7e0f343d8b59367f72b5dae96cf65696bdb8eeead8d7424ed37aa1434"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-speech"
+version = "11.1"
+description = "Wrappers for the framework Speech on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_speech-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5fcbe46060f0b25963e32fa7488a34fb3f929fa099797a10e30012d3d6ee328a"},
+    {file = "pyobjc_framework_speech-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d3e0276a66d2fa4357959a6f6fb5def03f8e0fd3aa43711d6a81ab2573b9415f"},
+    {file = "pyobjc_framework_speech-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7726eff52cfa9cc7178ddcd1285cbc23b5f89ee55b4b850b0d2e90bb4f8e044b"},
+    {file = "pyobjc_framework_speech-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3c80670dbad921bf1d4954a9de29525acb53ee84e064a95fbbdfddff1db2f14f"},
+    {file = "pyobjc_framework_speech-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f19778a4ace37c538a34a10ac1f595c80b83489210e6fa60c703399aee264c7e"},
+    {file = "pyobjc_framework_speech-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f36ca8a3cfc12b7a5cdf00712eec3ad0fac34e3da36b5737c5302e224525aa70"},
+    {file = "pyobjc_framework_speech-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:80e577e3dfc1c10a1280deae172cdb64e105f99f47343099e3968b720a3f68da"},
+    {file = "pyobjc_framework_speech-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8b464742b77693e398802a3184c6dbf49bd7ac8b86a0c8aa9d311d883df85c6a"},
+    {file = "pyobjc_framework_speech-11.1.tar.gz", hash = "sha256:d382977208c3710eacea89e05eae4578f1638bb5a7b667c06971e3d34e96845c"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-spritekit"
+version = "11.1"
+description = "Wrappers for the framework SpriteKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"13.0\""
+files = [
+    {file = "pyobjc_framework_spritekit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5adddbeea27ca748d4fd4588ffa79299fb7a7b369038bc6e3425570d1cab9b0a"},
+    {file = "pyobjc_framework_spritekit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1c8c94d37c054b6e3c22c237f6458c12649776e5ac921d066ab99dee2e580909"},
+    {file = "pyobjc_framework_spritekit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8b470a890db69e70ef428dfff88da499500fca9b2d44da7120dc588d13a2dbdb"},
+    {file = "pyobjc_framework_spritekit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2277e74d7be426181ae5ca7dd9d6c776426e8e825ad83b6046a7cb999015f27d"},
+    {file = "pyobjc_framework_spritekit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d6ea27fc202b40945729db50fdc6f75a0a11a07149febf4b99e14caf96ef33b0"},
+    {file = "pyobjc_framework_spritekit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:e04d0825109a0158e551e9e2a61c56e83eadfdc5a44a47b64cb410b0498d33be"},
+    {file = "pyobjc_framework_spritekit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:4e3673196b7cbc007e4aa7f14d711f3cda00e32e120bc4f6e896d54edd517c61"},
+    {file = "pyobjc_framework_spritekit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0519dac1eec99fcc94db2027b20ab445ed3a97cb9b2c5f02d737fcf436644d82"},
+    {file = "pyobjc_framework_spritekit-11.1.tar.gz", hash = "sha256:914da6e846573cac8db5e403dec9a3e6f6edf5211f9b7e429734924d00f65108"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-storekit"
+version = "11.1"
+description = "Wrappers for the framework StoreKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"11.0\""
+files = [
+    {file = "pyobjc_framework_storekit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:850b8157c30aa023c16a883a140538ca229d7b30db6c17568ea69532b19256ad"},
+    {file = "pyobjc_framework_storekit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:624105bd26a9ce5a097b3f96653e2700d33bb095828ed65ee0f4679b34d9f1e1"},
+    {file = "pyobjc_framework_storekit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5ca3373272b6989917c88571ca170ce6d771180fe1a2b44c7643fe084569b93e"},
+    {file = "pyobjc_framework_storekit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2e2607116b0d53d7fda2fc48e37b1deb1d26a60e7b723a6b7c391a3f48b2ac3b"},
+    {file = "pyobjc_framework_storekit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4944bd1fd01f486623453b68accf4445d3c5686714820c8329a0c4e4672d6fff"},
+    {file = "pyobjc_framework_storekit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d312c392962e15fc842d11b0f7d937e3bd9f3ed3a80f7a6be77518475564f04d"},
+    {file = "pyobjc_framework_storekit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:be6c894a9f9c2b40e300005c3a3cf46f352e1711f65c0b7a8dd5035d1f6333aa"},
+    {file = "pyobjc_framework_storekit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:390074ec81680f94e4a6a9f7b46438c0fcf96555092c363beb40e1b41f83574d"},
+    {file = "pyobjc_framework_storekit-11.1.tar.gz", hash = "sha256:85acc30c0bfa120b37c3c5ac693fe9ad2c2e351ee7a1f9ea6f976b0c311ff164"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-symbols"
+version = "11.1"
+description = "Wrappers for the framework Symbols on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"23.0\""
+files = [
+    {file = "pyobjc_framework_symbols-11.1-py2.py3-none-any.whl", hash = "sha256:1de6fc3af15fc8d5fd4869663a3250311844ec33e99ec8a1991a352ab61d641d"},
+    {file = "pyobjc_framework_symbols-11.1.tar.gz", hash = "sha256:0e09b7813ef2ebdca7567d3179807444dd60f3f393202b35b755d4e1baf99982"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-syncservices"
+version = "11.1"
+description = "Wrappers for the framework SyncServices on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_syncservices-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:108619faf4cafb894022ca923b52d45008eb6ad3af2123ca4e187101a74ddaee"},
+    {file = "pyobjc_framework_syncservices-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bc6159bda4597149c6999b052a35ffd9fc4817988293da6e54a1e073fa571653"},
+    {file = "pyobjc_framework_syncservices-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:03124c8c7c7ce837f51e1c9bdcf84c6f1d5201f92c8a1c172ec34908d5e57415"},
+    {file = "pyobjc_framework_syncservices-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:711d493c7967682bee605c5909a49d268d9b3dd3cb7a71d8ab5dbe01a069eb44"},
+    {file = "pyobjc_framework_syncservices-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a0ff222472b2cb5c345c92ae4bde245f4181843379f4fd9462cd5c096ed7b2f1"},
+    {file = "pyobjc_framework_syncservices-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:24c2b62e94d9e0e5e64abbf6d1f9994212b2a5cb8cad5a8d0394d694b20731b5"},
+    {file = "pyobjc_framework_syncservices-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e5b29d6e8fe5b0015dcac5485e4fe6ede35bae7beeb647fb81d86120365029ea"},
+    {file = "pyobjc_framework_syncservices-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4c294bfc33e60520a6652f1cc2a6f275f7cc923bd7ce87c2e305293cd2d20898"},
+    {file = "pyobjc_framework_syncservices-11.1.tar.gz", hash = "sha256:0f141d717256b98c17ec2eddbc983c4bd39dfa00dc0c31b4174742e73a8447fe"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreData = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-systemconfiguration"
+version = "11.1"
+description = "Wrappers for the framework SystemConfiguration on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:45ede697a3f9d4f97f1554a3f5636197aee83923d3adbe0901935da8ddb559a9"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d12d5078611c905162bc951dffbb2a989b0dfd156952ba1884736c8dcbe38f7f"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6881929b828a566bf1349f09db4943e96a2b33f42556e1f7f6f28b192420f6fc"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ab2ff52e4228f42182b7ef398d0da504f9f8f4a889963422af9aa1f495668db2"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c236f19cadc9fff56c0afb3e4ad6f8c8e11c5679e31ed413fe6876bf2ea73353"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:ef266e9f83c2fc9a999709626138b427ff052a0acf4851d797c3a7654878c046"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:b994c613b5bea9f1c9a64f57f373563c7f424ffae5e4cb20e76c8448a35543f7"},
+    {file = "pyobjc_framework_systemconfiguration-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:832e534e2b3daeb01c03dd6dba4540027caf2320b7b46a8c29f88d30decadcbd"},
+    {file = "pyobjc_framework_systemconfiguration-11.1.tar.gz", hash = "sha256:f30ed0e9a8233fecb06522e67795918ab230ddcc4a18e15494eff7532f4c3ae1"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-systemextensions"
+version = "11.1"
+description = "Wrappers for the framework SystemExtensions on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"19.0\""
+files = [
+    {file = "pyobjc_framework_systemextensions-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:55e33ce532c16e36e0960e34501748d07d019f8088aa4efde10c5c91ccbce5aa"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7e742ae51cdd86c0e609fe47189ea446de98d13b235b0a138a3f2e37e98cd359"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3a2b1e84e4a118bfe13efb9f2888b065dc937e2a7e60afd4d0a82b51b8301a10"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2ed65857244f18b88107e5d3ea8ea21c9da662490895b430e376423ee7c0b963"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9aa7595de4f8f6a252c50419c0343f7326c6a4de47da5b933a17880d1cadfa36"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:97c1b5f415f3981d0426516e014e94392f054f3898252bf6c88c3f50700c1d70"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:1801413066d1cbf2a0319e228060820c51ea0fb27aec339716d8c82f2e1b3125"},
+    {file = "pyobjc_framework_systemextensions-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f0356cafec3296e0dca1e7c9672c0be0aaf723050bb4fa4bfd054ca467e23666"},
+    {file = "pyobjc_framework_systemextensions-11.1.tar.gz", hash = "sha256:8ff9f0aad14dcdd07dd47545c1dd20df7a286306967b0a0232c81fcc382babe6"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-threadnetwork"
+version = "11.1"
+description = "Wrappers for the framework ThreadNetwork on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"22.0\""
+files = [
+    {file = "pyobjc_framework_threadnetwork-11.1-py2.py3-none-any.whl", hash = "sha256:55021455215a0d3ad4e40152f94154e29062e73655558c5f6e71ab097d90083e"},
+    {file = "pyobjc_framework_threadnetwork-11.1.tar.gz", hash = "sha256:73a32782f44b61ca0f8a4a9811c36b1ca1cdcf96c8a3ba4de35d8e8e58a86ad5"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "11.1"
+description = "Wrappers for the framework UniformTypeIdentifiers on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_uniformtypeidentifiers-11.1-py2.py3-none-any.whl", hash = "sha256:6e2e8ea89eb8ca03bc2bc8e506fff901e71d916276475c8d81fbf0280059cb4c"},
+    {file = "pyobjc_framework_uniformtypeidentifiers-11.1.tar.gz", hash = "sha256:86c499bec8953aeb0c95af39b63f2592832384f09f12523405650b5d5f1ed5e9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-usernotifications"
+version = "11.1"
+description = "Wrappers for the framework UserNotifications on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"18.0\""
+files = [
+    {file = "pyobjc_framework_usernotifications-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:863f9c680ce9d4b0d398a61803210e4c7ff770487b6506f00742dd45cd4d4347"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7140d337dd9dc3635add2177086429fdd6ef24970935b22fffdc5ec7f02ebf60"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ce6006989fd4a59ec355f6797ccdc9946014ea5241ff7875854799934dbba901"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9efa3004059a8fe3f3c52f638f0401dbcdbc7b2f539587c8868da2486a64d674"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:62a4bd242b761a6f00a4374a369391346d225d68be07691e042ec7db452084c8"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:dcdcb657d2fa47108e4ef93ec3320025576857e8f69a15f082f5eda930b35e86"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:bad5e650c014757159523466e5b2c127e066045e2a5579a5cac9aeca46bda017"},
+    {file = "pyobjc_framework_usernotifications-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bab02c31a07d3723df91de37e1e15d72770f717828efacf4bb058acb7bb82980"},
+    {file = "pyobjc_framework_usernotifications-11.1.tar.gz", hash = "sha256:38fc763afa7854b41ddfca8803f679a7305d278af8a7ad02044adc1265699996"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-usernotificationsui"
+version = "11.1"
+description = "Wrappers for the framework UserNotificationsUI on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_usernotificationsui-11.1-py2.py3-none-any.whl", hash = "sha256:b84d73d90ab319acf8fad5c59b7a5e2b6023fbb2efd68c58b532e3b3b52f647a"},
+    {file = "pyobjc_framework_usernotificationsui-11.1.tar.gz", hash = "sha256:18e0182bddd10381884530d6a28634ebb3280912592f8f2ad5bac2a9308c6a65"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-UserNotifications = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-videosubscriberaccount"
+version = "11.1"
+description = "Wrappers for the framework VideoSubscriberAccount on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"18.0\""
+files = [
+    {file = "pyobjc_framework_videosubscriberaccount-11.1-py2.py3-none-any.whl", hash = "sha256:d5a95ae9f2a6f0180a5bbb10e76c064f0fd327aae00a2fe90aa7b65ed4dad7ef"},
+    {file = "pyobjc_framework_videosubscriberaccount-11.1.tar.gz", hash = "sha256:2dd78586260fcee51044e129197e8bf2e157176e02babeec2f873afa4235d8c6"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-videotoolbox"
+version = "11.1"
+description = "Wrappers for the framework VideoToolbox on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"12.0\""
+files = [
+    {file = "pyobjc_framework_videotoolbox-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:dad01cdc1fe2b5ca4ba4f2472eb62fca87898e1a4ade3b692177bb09a07d4254"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:94c17bffe0f4692db2e7641390dfdcd0f73ddbb0afa6c81ef504219be0777930"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c55285c3c78183fd2a092d582e30b562777a82985cccca9e7e99a0aff2601591"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:65a96385e80cb9ad3eab7d1f3156452ff805a925c9ca287ff1491a97cca191ba"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e282cb07f6a51647ac19a3b5d31e26f1619285bac24171e403921d671e4756d9"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:31acfb12cea4f0624ecb92e74404f15e2755fbf0a3f4133dc93add44cf4a6a9f"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e54bd6cfcbdda4add24e8e873baab11dfb436633100cc6664f3c068e615a6ff"},
+    {file = "pyobjc_framework_videotoolbox-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:df39385ffe4b32d40e8d97414356de1dcc16ef20678c7556d2c513286f42985f"},
+    {file = "pyobjc_framework_videotoolbox-11.1.tar.gz", hash = "sha256:a27985656e1b639cdb102fcc727ebc39f71bb1a44cdb751c8c80cc9fe938f3a9"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreMedia = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-virtualization"
+version = "11.1"
+description = "Wrappers for the framework Virtualization on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"20.0\""
+files = [
+    {file = "pyobjc_framework_virtualization-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:27b3149426ab80583d8b40a0c0829d0968621b2c406abeeee1ac7ba3f25f9949"},
+    {file = "pyobjc_framework_virtualization-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c2a812da4c995e1f8076678130d0b0a63042aa48219f8fb43b70e13eabcbdbc2"},
+    {file = "pyobjc_framework_virtualization-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:59df6702b3e63200752be7d9c0dc590cb4c3b699c886f9a8634dd224c74b3c3c"},
+    {file = "pyobjc_framework_virtualization-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:12a5ef32d2b7a56b675ea34fcb68bb9dddb7cf2c0a5ac5131f35551767bdacf1"},
+    {file = "pyobjc_framework_virtualization-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:790bd2e42e8c5890319f8c576d5e171f87f95655e6fc55cf19a5f85f9e23558a"},
+    {file = "pyobjc_framework_virtualization-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:5f35d823003a613bde27c2c699a8a7de45dc2bdd2e1121e0c4a337b877dfc64e"},
+    {file = "pyobjc_framework_virtualization-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:b2e7ab5204fe80249dd8d031b761cf9c0106d0d5e61d88930e0f334f5060d820"},
+    {file = "pyobjc_framework_virtualization-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0d2db7abc0ba7b33611c2596f210e4b4f2d49b68d2df71e82e8f0126f50bb4ba"},
+    {file = "pyobjc_framework_virtualization-11.1.tar.gz", hash = "sha256:4221ee5eb669e43a2ff46e04178bec149af2d65205deb5d4db5fa62ea060e022"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-vision"
+version = "11.1"
+description = "Wrappers for the framework Vision on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and platform_release >= \"17.0\""
+files = [
+    {file = "pyobjc_framework_vision-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3c6f46df632096f070e16ba902a483fcb95c01fe12856a071bc2b25ac4a89bf3"},
+    {file = "pyobjc_framework_vision-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bfbde43c9d4296e1d26548b6d30ae413e2029425968cd8bce96d3c5a735e8f2c"},
+    {file = "pyobjc_framework_vision-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:df076c3e3e672887182953efc934c1f9683304737e792ec09a29bfee90d2e26a"},
+    {file = "pyobjc_framework_vision-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1e5617e37dd2a7cff5e69e9aab039ea74b39ccdc528f6c828f2b60c1254e61e5"},
+    {file = "pyobjc_framework_vision-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dfd148a6df30ac70a9c41dd90a6c8f8c7f339bd9ca6829629a902f272e02b6b4"},
+    {file = "pyobjc_framework_vision-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d1f8fdccc6135fdbfd66d8f21240d6c84465cb8e116a8e5b43601aed020051e5"},
+    {file = "pyobjc_framework_vision-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d00830c71a30fc893b3c5ee65119c7e5e5a95a16af53b8e56a0e58cff57e3b56"},
+    {file = "pyobjc_framework_vision-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:25d2d42edc7459b010ec87a0c5428d12fe5d62dfa95cd34fb71f716f2e4d6b95"},
+    {file = "pyobjc_framework_vision-11.1.tar.gz", hash = "sha256:26590512ee7758da3056499062a344b8a351b178be66d4b719327884dde4216b"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+pyobjc-framework-CoreML = ">=11.1"
+pyobjc-framework-Quartz = ">=11.1"
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "11.1"
+description = "Wrappers for the framework WebKit on macOS"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_webkit-11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5e7c254ba37b7a41fe9ffd31565495cad961a82ab22727949cdb4aface7f3fa6"},
+    {file = "pyobjc_framework_webkit-11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:10ec89d727af8f216ba5911ff5553f84a5b660f5ddf75b07788e3a439c281165"},
+    {file = "pyobjc_framework_webkit-11.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1a6e6f64ca53c4953f17e808ecac11da288d9a6ade738156ba161732a5e0c96a"},
+    {file = "pyobjc_framework_webkit-11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1d01008756c3912b02b7c02f62432467fbee90a93e3b8e31fa351b4ca97c9c98"},
+    {file = "pyobjc_framework_webkit-11.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:864f9867a2caaeaeb83e5c0fa3dcf78169622233cf93a9a5eeb7012ced3b8076"},
+    {file = "pyobjc_framework_webkit-11.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:13b774d4244734cb77bf3c3648149c163f62acaa105243d7c48bb3fd856b5628"},
+    {file = "pyobjc_framework_webkit-11.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:c1c00d549ab1d50e3d7e8f5f71352b999d2c32dc2365c299f317525eb9bff916"},
+    {file = "pyobjc_framework_webkit-11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:94534450e4b3c0a4fe8ad4fa9258afc07ebfe36e1b3966f0fb5cd437c89ccfbf"},
+    {file = "pyobjc_framework_webkit-11.1.tar.gz", hash = "sha256:27e701c7aaf4f24fc7e601a128e2ef14f2773f4ab071b9db7438dc5afb5053ae"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=11.1"
+pyobjc-framework-Cocoa = ">=11.1"
+
+[[package]]
+name = "pyperclip"
+version = "1.9.0"
+description = "A cross-platform clipboard module for Python. (Only handles plain text for now.)"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310"},
+]
 
 [[package]]
 name = "pytest"
@@ -1621,4 +5238,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "cefb56933704731c2f884be1b037a9aad4cfcec7643ec3c9880b105afb3f8e3e"
+content-hash = "b138c269d4d5edde58a257ca5374602da37c7061ea0b2ab1077330e07ec70f0b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ pyyaml = "^6.0.1"
 typer = "^0.9.0"
 requests = "^2.31.0"
 httpx = "^0.27.0"
+pyperclip = "^1.8.2"
+keyboard = "^0.13.5"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.2"


### PR DESCRIPTION
## Summary
- add fallback prompt generator to suggest using GPT/Claude
- record pasted responses with a new pasteback handler
- trigger cloud prompt suggestions from `LLMRouter`
- store pasteback data in backend websocket handler
- surface pasteback workflow in the React frontend
- include optional clipboard monitor plugin
- update dependencies for clipboard support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1ffb8f24832bbc03ed8dc88b92bd