### PR TITLE
Fix ruff error in clipboard monitor

### DIFF
--- a/plugins/clipboard_monitor.py
+++ b/plugins/clipboard_monitor.py
@@ -4,7 +4,7 @@ import time
 try:
     import pyperclip
     import keyboard
-except Exception as e:  # pragma: no cover - optional dependency
+except Exception:  # pragma: no cover - optional dependency
     pyperclip = None
     keyboard = None
 


### PR DESCRIPTION
## Summary
- fix F841 by removing unused exception variable in `plugins/clipboard_monitor.py`

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b82fc2ed8832baa59db0c33726e63