### PR TITLE
Start MCP servers via docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ pip-delete-this-directory.txt
 # OS
 .DS_Store
 Thumbs.db
+markdown_notes/
+=1.5

--- a/README.md
+++ b/README.md
@@ -23,3 +23,18 @@ plugin provides metadata such as name, description, and usage via the
 
 Goals can be stored via the `/goals/{thread_id}` API for simple task tracking.
 
+## Docker Compose
+
+The repository includes a `docker-compose.yml` for running Axon and its
+dependencies in containers. This setup also launches the MCP helper servers so
+they are available automatically.
+
+```bash
+# build and start all services
+cp .env.example .env  # configure environment variables if needed
+docker compose up --build
+```
+
+The frontend will be available on `http://localhost:3000` and the backend on
+`http://localhost:8000`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,32 @@ services:
       - /app/.venv
     env_file:
       - .env
+    environment:
+      FILESYSTEM_MCP_URL: http://mcp_servers:9001
+      TIME_MCP_URL: http://mcp_servers:9002
+      CALC_MCP_URL: http://mcp_servers:9003
+      MARKDOWN_MCP_URL: http://mcp_servers:9004
     depends_on:
       - postgres
       - qdrant
+      - mcp_servers
     command: ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+
+  mcp_servers:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    command: ["python", "-m", "mcp_servers"]
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+      - /app/.venv
+    ports:
+      - "9001:9001"
+      - "9002:9002"
+      - "9003:9003"
+      - "9004:9004"
 
   postgres:
     image: postgres:15


### PR DESCRIPTION
## Summary
- make docker compose spin up mcp servers
- let backend point to those servers via environment variables
- document docker compose usage
- ignore generated notes from tests

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8b6b9c28832ba629fd09cb22778b