### PR TITLE
Implement manual remote model fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ docker compose up --build
 The frontend will be available on `http://localhost:3000` and the backend on
 `http://localhost:8000`.
 
+## Remote model fallback
+
+Axon can suggest prompts for hosted models like GPT-4o or Claude when the local
+LLM appears inadequate. The UI will display the generated prompt and provide a
+text area for pasting back the remote response. For quick manual pasting you can
+run `python scripts/clipboard_watch.py` to monitor your clipboard.
+

--- a/agent/fallback_prompt.py
+++ b/agent/fallback_prompt.py
@@ -1,24 +1,55 @@
 from dataclasses import dataclass
 import json
+from typing import Tuple
+
 
 @dataclass
 class FallbackPrompt:
-    """Metadata for a prompt intended for a remote LLM"""
+    """Metadata for a prompt intended for a remote LLM."""
+
     model: str
     prompt: str
     reason: str
 
-def generate_prompt(user_message: str, model: str = "gpt-4o", reason: str | None = None) -> dict:
+
+def suggest_model(user_message: str) -> Tuple[str, str]:
+    """Suggest a cloud model and reason based on the message."""
+
+    lowered = user_message.lower()
+    if "summarize" in lowered or "summary" in lowered:
+        return (
+            "claude-3-sonnet",
+            "Claude is recommended for summarization tasks.",
+        )
+    return (
+        "gpt-4o",
+        "Local model may be insufficient for this request.",
+    )
+
+
+def generate_prompt(
+    user_message: str, model: str | None = None, reason: str | None = None
+) -> dict:
     """Return a dict describing a cloud prompt."""
-    if reason is None:
-        reason = "Local model may be insufficient for this request."
+
+    if model is None or reason is None:
+        suggested_model, suggested_reason = suggest_model(user_message)
+        model = model or suggested_model
+        reason = reason or suggested_reason
+
     prompt = (
         "You are Axon's remote assistant. "
         f"Please answer the following user request:\n{user_message}"
     )
-    return {"type": "cloud_prompt", "model": model, "prompt": prompt, "reason": reason}
+    return {
+        "type": "cloud_prompt",
+        "model": model,
+        "prompt": prompt,
+        "reason": reason,
+    }
 
 
 def to_json(data: dict) -> str:
     """Serialize fallback prompt dict to JSON string."""
+
     return json.dumps(data)

--- a/agent/llm_router.py
+++ b/agent/llm_router.py
@@ -22,6 +22,7 @@ class LLMRouter:
 
     def _needs_cloud(self, prompt: str) -> bool:
         """Simple heuristic to decide if a cloud model should be suggested."""
+
         return len(prompt) > 400
 
     def get_response(self, prompt: str, model: str) -> str:
@@ -46,5 +47,8 @@ class LLMRouter:
             return response_data.get("response", "Sorry, I received an empty response from Ollama.").strip()
 
         except requests.exceptions.RequestException:
-            fallback = generate_prompt(prompt)
+            fallback = generate_prompt(
+                prompt,
+                reason="Local model call failed; please use a cloud model.",
+            )
             return to_json(fallback)

--- a/scripts/clipboard_watch.py
+++ b/scripts/clipboard_watch.py
@@ -1,0 +1,23 @@
+import time
+import pyperclip
+
+
+def watch_clipboard() -> None:
+    """Print clipboard updates until interrupted."""
+
+    print("Watching clipboard. Press Ctrl+C to stop.")
+    last = pyperclip.paste()
+    try:
+        while True:
+            current = pyperclip.paste()
+            if current != last:
+                print("\n--- clipboard updated ---\n")
+                print(current)
+                last = current
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        print("\nClipboard watch stopped.")
+
+
+if __name__ == "__main__":
+    watch_clipboard()

--- a/tests/test_remote_fallback.py
+++ b/tests/test_remote_fallback.py
@@ -1,0 +1,18 @@
+from agent.fallback_prompt import suggest_model, generate_prompt
+from agent.llm_router import LLMRouter
+import json
+
+
+def test_suggest_model():
+    model, reason = suggest_model("Please summarize this text")
+    assert model.startswith("claude")
+    assert "summarization" in reason.lower()
+
+
+def test_llm_router_cloud_prompt_on_long_input():
+    router = LLMRouter(server_url="http://invalid")
+    long_msg = "x" * 500
+    result = router.get_response(long_msg, model="local")
+    data = json.loads(result)
+    assert data["type"] == "cloud_prompt"
+    assert "prompt" in data


### PR DESCRIPTION
## Summary
- add heuristic-based remote model suggestion
- generate fallback prompts with reasons
- handle local model failures gracefully
- include clipboard watcher utility
- document manual pasteback workflow
- test remote fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be7b29df4832b84abcc13e6766512