### PR TITLE
Fix MCP server binding

### DIFF
--- a/mcp_servers/__main__.py
+++ b/mcp_servers/__main__.py
@@ -13,7 +13,8 @@ SERVERS = [
 ]
 
 def run(app, port):
-    uvicorn.run(app, host="127.0.0.1", port=port)
+    # Listen on all interfaces so the backend container can reach the servers
+    uvicorn.run(app, host="0.0.0.0", port=port)
 
 if __name__ == "__main__":
     processes = []


### PR DESCRIPTION
## Summary
- run MCP servers on `0.0.0.0` so the backend container can connect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be5b0333c832ba3e93e81ce438ca1