### PR TITLE
Implement pasteback handler test

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The frontend will be available on `http://localhost:3000` and the backend on
 
 Axon can suggest prompts for hosted models like GPT-4o or Claude when the local
 LLM appears inadequate. The UI will display the generated prompt and provide a
-text area for pasting back the remote response. For quick manual pasting you can
-run `python scripts/clipboard_watch.py` to monitor your clipboard.
+text area for pasting back the remote response. Press **Submit** after pasting
+to store the result in memory. For quick manual pasting you can run
+`python scripts/clipboard_watch.py` to monitor your clipboard.
 

--- a/agent/pasteback_handler.py
+++ b/agent/pasteback_handler.py
@@ -1,10 +1,22 @@
 import time
-from memory.memory_handler import MemoryHandler
+from typing import Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from memory.memory_handler import MemoryHandler
+
+
+class MemoryLike(Protocol):
+    """Minimal interface needed from MemoryHandler."""
+
+    def add_fact(
+        self, thread_id: str, key: str, value: str, identity: str | None = None
+    ) -> None:
+        ...
 
 class PastebackHandler:
     """Store remote model responses in memory."""
 
-    def __init__(self, memory_handler: MemoryHandler):
+    def __init__(self, memory_handler: MemoryLike):
         self.memory_handler = memory_handler
 
     def store(self, thread_id: str, prompt: str, response: str, model: str = "gpt") -> None:

--- a/tests/test_pasteback_handler.py
+++ b/tests/test_pasteback_handler.py
@@ -1,0 +1,23 @@
+from agent.pasteback_handler import PastebackHandler
+
+class DummyMemory:
+    def __init__(self):
+        self.calls = []
+    def add_fact(self, thread_id, key, value, identity=None):
+        self.calls.append((thread_id, key, value, identity))
+
+
+def test_store_adds_two_facts():
+    mem = DummyMemory()
+    handler = PastebackHandler(mem)
+    handler.store('t1', 'prompt text', 'reply text', model='gpt-4o')
+    assert len(mem.calls) == 2
+    first_key = mem.calls[0][1]
+    second_key = mem.calls[1][1]
+    assert first_key.startswith('cloud_prompt_')
+    assert second_key.startswith('cloud_response_')
+    assert mem.calls[0][0] == 't1'
+    assert mem.calls[0][2] == 'prompt text'
+    assert mem.calls[1][2] == 'reply text'
+    assert mem.calls[0][3] == 'gpt-4o'
+    assert mem.calls[1][3] == 'gpt-4o'


### PR DESCRIPTION
## Summary
- avoid importing psycopg2 when using `PastebackHandler`
- document how to submit remote model replies
- test storing pasteback facts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c395ed7bc832ba310f37734746c15