### PR TITLE
Improve docs and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ text area for pasting back the remote response. Press **Submit** after pasting
 to store the result in memory. For quick manual pasting you can run
 `python scripts/clipboard_watch.py` to monitor your clipboard.
 
+
+## Documentation
+
+- [docs/plugins.md](docs/plugins.md) explains how to create new plugins.
+- [docs/mcp_setup.md](docs/mcp_setup.md) covers running the MCP helper services.
+- [docs/models.md](docs/models.md) shows how to change the default model.
+
+Example local configuration files are available in `.env.example` and `config/settings.example.yaml`.
+
+## Roadmap progress
+
+Phase 0 has been completed and the Phase 1 MVP scaffold is implemented. See [phases/roadmap.md](phases/roadmap.md) for upcoming work.
+

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -1,0 +1,7 @@
+database:
+  postgres_uri: "postgresql://user:password@localhost:5432/axon_db"
+  qdrant_host: "localhost"
+  qdrant_port: 6333
+
+llm:
+  default_local_model: "qwen3:8b"

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -1,0 +1,19 @@
+# MCP Environment Setup
+
+Axon bundles a set of helper servers that speak the Model Context Protocol (MCP). They provide basic filesystem, time and calculator operations and a markdown note store.
+
+When using Docker these servers are started automatically alongside the backend. For local development you can run them with Python:
+
+```bash
+python -m mcp_servers
+```
+
+This launches the following services on localhost:
+
+- **Filesystem** – `http://localhost:9001`
+- **Time** – `http://localhost:9002`
+- **Calculator** – `http://localhost:9003`
+- **Markdown Backup** – `http://localhost:9004`
+
+The backend expects these URLs via environment variables when running in containers. They can be customised in `docker-compose.yml` or your shell environment.
+

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,17 @@
+# Customising Models
+
+LLM calls are routed through `agent.llm_router.LLMRouter`. By default the router targets a local Ollama server and falls back to prompting for a cloud model when the input is very long.
+
+The default model used by the backend is configured in `config/settings.yaml` under `llm.default_local_model`. Update this value to switch models globally.
+
+To point the router at a different server you can pass the `server_url` when creating `LLMRouter` in `backend/main.py` or set the environment variable `OLLAMA_URL` and modify the code accordingly.
+
+Example `settings.yaml` snippet:
+
+```yaml
+llm:
+  default_local_model: "mistral:7b"
+```
+
+Restart the backend after changing settings so the new model is loaded.
+

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,21 @@
+# Writing Plugins
+
+Axon supports simple Python plugins that can add new commands or actions. Plugins live in the `plugins/` folder and are discovered at startup.
+
+Each plugin defines a function decorated with `@plugin` from `agent.plugin_loader`. Metadata such as name, description and usage are provided to help the agent advertise available skills.
+
+```python
+# plugins/echo.py
+from agent.plugin_loader import plugin
+
+@plugin(
+    name="echo",
+    description="Echo back the provided text",
+    usage="echo('hello')"
+)
+def echo(text: str) -> str:
+    return text
+```
+
+Restart the CLI (`python main.py cli`) or the web backend to load new or changed plugins. During development the loader hot‑reloads modules so edits take effect immediately.
+

--- a/phases/roadmap.md
+++ b/phases/roadmap.md
@@ -13,20 +13,20 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 
 ---
 
-## 🚧 Phase 1: Core MVP Scaffold
+## ✅ Phase 1: Core MVP Scaffold (Complete)
 **Goal:** Local-only chat agent with working memory and UI
 
-- [ ] `main.py`: Bootloader with CLI, web, and headless modes
-- [ ] `settings.yaml` and `.env.example` scaffolds
-- [ ] `memory_handler.py`: PostgreSQL fact storage
-- [ ] `vector_store.py`: Qdrant connection with hybrid retrieval
-- [ ] `llm_router.py`: local model selector and fallback handler
-- [ ] `mcp_handler.py`: parse/generate MCP messages
-- [ ] Sample facts and MCP messages in memory
-- [ ] Frontend: React split-pane (chat + memory)
-- [ ] Backend: FastAPI API endpoints + WebSocket
-- [ ] Docker Compose: Postgres + Qdrant + backend + frontend
-- [ ] CI: GitHub Actions with mypy + ruff checks
+- [x] `main.py`: Bootloader with CLI, web, and headless modes
+- [x] `settings.yaml` and `.env.example` scaffolds
+- [x] `memory_handler.py`: PostgreSQL fact storage
+- [x] `vector_store.py`: Qdrant connection with hybrid retrieval
+- [x] `llm_router.py`: local model selector and fallback handler
+- [x] `mcp_handler.py`: parse/generate MCP messages
+- [x] Sample facts and MCP messages in memory
+- [x] Frontend: React split-pane (chat + memory)
+- [x] Backend: FastAPI API endpoints + WebSocket
+- [x] Docker Compose: Postgres + Qdrant + backend + frontend
+- [x] CI: GitHub Actions with mypy + ruff checks
 
 ---
 


### PR DESCRIPTION
## Summary
- document plugin development
- add setup docs for MCP servers and model configuration
- include example settings file
- link docs from README and note progress
- update roadmap status for phase 1

## Testing
- `pip install fastapi uvicorn pydantic pydantic-settings python-dotenv psycopg2-binary qdrant-client pyyaml typer requests httpx pyperclip keyboard plyer ruff mypy pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c4052f88c832b97336bdd95e4d3d5