### PR TITLE
Add automatic goal detection

### DIFF
--- a/agent/goal_tracker.py
+++ b/agent/goal_tracker.py
@@ -4,6 +4,7 @@
 
 import psycopg2
 from typing import Optional
+import re
 from config.settings import settings
 
 
@@ -42,6 +43,17 @@ class GoalTracker:
                 (thread_id, identity, text),
             )
             self.conn.commit()
+
+    def detect_and_add_goal(
+        self, thread_id: str, message: str, identity: Optional[str] = None
+    ) -> bool:
+        """Detect goal-related phrases in a message and log them."""
+        patterns = [r"i want to .+", r"remind me .+"]
+        for pat in patterns:
+            if re.search(pat, message, re.IGNORECASE):
+                self.add_goal(thread_id, message, identity)
+                return True
+        return False
 
     def list_goals(self, thread_id: str):
         if not self.conn:

--- a/backend/main.py
+++ b/backend/main.py
@@ -122,6 +122,11 @@ async def websocket_endpoint(websocket: WebSocket):
             data = await websocket.receive_text()
             logging.info(f"Received message: '{data}'")
 
+            # Automatically log goal-related messages
+            goal_tracker.detect_and_add_goal(
+                thread_id, data, identity="default_user"
+            )
+
             response_message = ""
             remember_match = re.match(r"remember (.*) is (.*)", data, re.IGNORECASE)
 

--- a/tests/test_goal_detection.py
+++ b/tests/test_goal_detection.py
@@ -1,0 +1,14 @@
+from agent.goal_tracker import GoalTracker
+
+
+def test_detect_goal_creates_entry(monkeypatch):
+    tracker = GoalTracker.__new__(GoalTracker)
+    calls = []
+
+    def dummy_add(thread_id, text, identity=None):
+        calls.append((thread_id, text, identity))
+
+    monkeypatch.setattr(tracker, "add_goal", dummy_add)
+    result = tracker.detect_and_add_goal("t1", "I want to learn Python")
+    assert result is True
+    assert calls == [("t1", "I want to learn Python", None)]


### PR DESCRIPTION
## Summary
- detect goal phrases in GoalTracker
- auto-log goals in websocket
- test that goal detection logs goal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cd698a98c832ba17e6c07bacda9d4