### PR TITLE
Add deferred idea logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ plugin provides metadata such as name, description, and usage via the
 `@plugin` decorator.
 
 Goals can be stored via the `/goals/{thread_id}` API for simple task tracking.
+Ideas that sound vague ("someday I might...") are marked as **deferred** and
+can be listed via `/goals/{thread_id}/deferred`.
 
 ## Docker Compose
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,8 +94,31 @@ async def list_goals(thread_id: str):
     goals = goal_tracker.list_goals(thread_id)
     return {
         "goals": [
-            {"id": g_id, "text": text, "completed": done, "identity": ident}
-            for g_id, text, done, ident in goals
+            {
+                "id": g_id,
+                "text": text,
+                "completed": done,
+                "identity": ident,
+                "deferred": deferred,
+            }
+            for g_id, text, done, ident, deferred in goals
+        ]
+    }
+
+
+@app.get("/goals/{thread_id}/deferred")
+async def list_deferred(thread_id: str):
+    goals = goal_tracker.list_deferred_goals(thread_id)
+    return {
+        "goals": [
+            {
+                "id": g_id,
+                "text": text,
+                "completed": done,
+                "identity": ident,
+                "deferred": deferred,
+            }
+            for g_id, text, done, ident, deferred in goals
         ]
     }
 

--- a/tests/test_goal_deferred.py
+++ b/tests/test_goal_deferred.py
@@ -1,0 +1,45 @@
+from agent.goal_tracker import GoalTracker
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.fetchall_result = []
+    def execute(self, query, params=None):
+        self.queries.append((query.strip(), params))
+    def fetchall(self):
+        return self.fetchall_result
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyConn:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        pass
+    def close(self):
+        pass
+
+
+def test_add_goal_marks_deferred(monkeypatch):
+    cur = DummyCursor()
+    conn = DummyConn(cur)
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
+    tracker = GoalTracker(db_uri="postgresql://ignore")
+    tracker.add_goal("t1", "Someday I might travel")
+    insert_query, params = cur.queries[-1]
+    assert "INSERT INTO goals" in insert_query
+    assert params == ("t1", None, "Someday I might travel", True)
+
+
+def test_list_deferred(monkeypatch):
+    cur = DummyCursor()
+    cur.fetchall_result = [(1, "Someday I might travel", False, None, True)]
+    conn = DummyConn(cur)
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
+    tracker = GoalTracker(db_uri="postgresql://ignore")
+    goals = tracker.list_deferred_goals("t1")
+    assert goals == cur.fetchall_result


### PR DESCRIPTION
## Summary
- track deferred goal ideas in database
- expose a new API endpoint for listing deferred ideas
- mark vague goals like "someday I might" as deferred
- document deferred idea tracking
- test deferred goal behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdd1cbb58832bbd375862824fe130