### PR TITLE
Track speaker identity in context manager

### DIFF
--- a/agent/context_manager.py
+++ b/agent/context_manager.py
@@ -1,19 +1,36 @@
 # axon/agent/context_manager.py
 
+from dataclasses import dataclass
+from typing import List, Optional
+
 from memory.memory_handler import MemoryHandler
+from agent.goal_tracker import GoalTracker
 from config.settings import settings
 
+
+@dataclass
+class ChatMessage:
+    identity: str
+    text: str
+
 class ContextManager:
-    """
-    Manages the current conversational context, including thread_id and identity.
-    """
-    def __init__(self, thread_id: str = "default_thread", identity: str = "default_user"):
+    """Manages the current conversational context, including thread and identity."""
+
+    def __init__(
+        self,
+        thread_id: str = "default_thread",
+        identity: str = "default_user",
+        goal_tracker: Optional[GoalTracker] = None,
+    ) -> None:
         self.thread_id = thread_id
         self.identity = identity
-        # Initialize the memory handler here, assuming it's needed per context
         self.memory_handler = MemoryHandler(db_uri=settings.database.postgres_uri)
+        self.goal_tracker = goal_tracker or GoalTracker(
+            db_uri=settings.database.postgres_uri
+        )
+        self.chat_history: List[ChatMessage] = []
 
-    def add_fact(self, key: str, value: str):
+    def add_fact(self, key: str, value: str, identity: Optional[str] = None) -> None:
         """
         Adds a fact to memory within the current context.
         """
@@ -21,14 +38,16 @@ class ContextManager:
             thread_id=self.thread_id,
             key=key,
             value=value,
-            identity=self.identity
+            identity=identity or self.identity,
         )
 
-    def get_fact(self, key: str):
+    def get_fact(self, key: str, include_identity: bool = False):
         """
         Retrieves a fact from memory within the current context.
         """
-        return self.memory_handler.get_fact(thread_id=self.thread_id, key=key)
+        return self.memory_handler.get_fact(
+            thread_id=self.thread_id, key=key, include_identity=include_identity
+        )
 
     def set_identity(self, identity: str):
         """
@@ -55,4 +74,13 @@ class ContextManager:
 
     def set_lock(self, key: str, locked: bool) -> bool:
         return self.memory_handler.set_lock(self.thread_id, key, locked)
+
+    def add_chat_message(self, text: str, identity: Optional[str] = None) -> None:
+        """Record a chat message with its speaker identity and detect goals."""
+        speaker = identity or self.identity
+        self.chat_history.append(ChatMessage(identity=speaker, text=text))
+        if self.goal_tracker:
+            self.goal_tracker.detect_and_add_goal(
+                self.thread_id, text, identity=speaker
+            )
 

--- a/memory/memory_handler.py
+++ b/memory/memory_handler.py
@@ -77,20 +77,25 @@ class MemoryHandler:
             self.conn.commit()
             print(f"Added/Updated fact for thread {thread_id}: {key} = {value} (Identity: {identity})")
 
-    def get_fact(self, thread_id: str, key: str):
-        """
-        Retrieves a fact from the database for a given thread and key.
-        """
+    def get_fact(self, thread_id: str, key: str, include_identity: bool = False):
+        """Retrieve a fact and optionally its identity for a given thread."""
         if not self.conn:
             print("No database connection.")
             return None
 
         with self.conn.cursor() as cur:
-            query = sql.SQL("SELECT value FROM facts WHERE thread_id = %s AND key = %s")
+            query = sql.SQL(
+                "SELECT value, identity FROM facts WHERE thread_id = %s AND key = %s"
+            )
             cur.execute(query, (thread_id, key))
             result = cur.fetchone()
-            print(f"Retrieved fact for thread {thread_id} with key {key}: {'Found' if result else 'Not Found'}")
-            return result[0] if result else None
+            print(
+                f"Retrieved fact for thread {thread_id} with key {key}: {'Found' if result else 'Not Found'}"
+            )
+            if not result:
+                return None
+            value, ident = result
+            return (value, ident) if include_identity else value
 
     def list_facts(self, thread_id: str) -> list[tuple[str, str, str | None, bool]]:
         """Returns all facts for a thread including lock state."""

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,29 @@
+from agent.context_manager import ContextManager, ChatMessage
+
+class DummyMemory:
+    def __init__(self):
+        self.add_calls = []
+    def add_fact(self, thread_id, key, value, identity=None):
+        self.add_calls.append((thread_id, key, value, identity))
+    def update_fact(self, *a, **k):
+        pass
+    def delete_fact(self, *a, **k):
+        return False
+    def set_lock(self, *a, **k):
+        return False
+
+class DummyGoalTracker:
+    def __init__(self):
+        self.detect_calls = []
+    def detect_and_add_goal(self, thread_id, text, identity=None):
+        self.detect_calls.append((thread_id, text, identity))
+
+
+def test_chat_history_records_identity(monkeypatch):
+    monkeypatch.setattr("agent.context_manager.MemoryHandler", lambda db_uri=None: DummyMemory())
+    tracker = DummyGoalTracker()
+    cm = ContextManager(thread_id="t1", identity="alice", goal_tracker=tracker)
+    cm.add_chat_message("hello")
+    cm.add_chat_message("hi", identity="bob")
+    assert cm.chat_history == [ChatMessage("alice", "hello"), ChatMessage("bob", "hi")]
+    assert tracker.detect_calls[-1] == ("t1", "hi", "bob")

--- a/tests/test_memory_identity.py
+++ b/tests/test_memory_identity.py
@@ -1,0 +1,37 @@
+from memory.memory_handler import MemoryHandler
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.fetch_result = ("v1", "alice")
+    def execute(self, query, params=None):
+        self.queries.append((str(query).strip(), params))
+    def fetchone(self):
+        return self.fetch_result
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyConn:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        pass
+    def close(self):
+        pass
+
+
+def test_get_fact_with_identity(monkeypatch):
+    cur = DummyCursor()
+    conn = DummyConn(cur)
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
+    handler = MemoryHandler(db_uri="postgresql://ignore")
+    value_only = handler.get_fact("t1", "k1")
+    assert value_only == "v1"
+    result = handler.get_fact("t1", "k1", include_identity=True)
+    assert result == ("v1", "alice")
+    query, params = cur.queries[-1]
+    assert params == ("t1", "k1")


### PR DESCRIPTION
## Summary
- track chat speaker identity in `ContextManager`
- allow retrieving memory identity via `get_fact`
- record chat messages and detect goals with identity
- add tests for per-identity memory and chat log tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cde55fa24832bba9c2550e6a9feb3