### PR TITLE
Add remember CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Run `python main.py cli` to load plugins (hot reloaded each launch). Each
 plugin provides metadata such as name, description, and usage via the
 `@plugin` decorator.
 
+To store a fact without using the UI, you can run:
+
+```bash
+python main.py remember "topic" "fact"
+```
+This writes the key/value pair directly to Axon's memory.
+
 Goals can be stored via the `/goals/{thread_id}` API for simple task tracking.
 Ideas that sound vague ("someday I might...") are marked as **deferred** and
 can be listed via `/goals/{thread_id}/deferred`.

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import asyncio
 from agent.plugin_loader import load_plugins, AVAILABLE_PLUGINS
 from memory.user_profile import UserProfileManager
 from agent.reminder import ReminderManager
+from agent.context_manager import ContextManager
 
 # Global managers used across commands
 profile_manager = UserProfileManager()
@@ -97,6 +98,14 @@ def remind(message: str, delay: int = 60) -> None:
     """Schedule a reminder in seconds."""
     reminder_manager.schedule(message, delay)
     print(f"Reminder set in {delay} seconds: {message}")
+
+
+@app.command()
+def remember(topic: str, fact: str, thread_id: str = "cli_thread", identity: str = "cli_user") -> None:
+    """Store a fact directly into Axon's memory."""
+    cm = ContextManager(thread_id=thread_id, identity=identity)
+    cm.add_fact(topic, fact)
+    print(f"Remembered '{topic}' = '{fact}'.")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_remember.py
+++ b/tests/test_cli_remember.py
@@ -1,0 +1,19 @@
+from typer.testing import CliRunner
+import main
+
+
+def test_remember_command(monkeypatch):
+    calls = []
+
+    class DummyCM:
+        def __init__(self, thread_id="cli_thread", identity="cli_user", goal_tracker=None):
+            pass
+        def add_fact(self, key, value):
+            calls.append((key, value))
+
+    monkeypatch.setattr(main, "ContextManager", DummyCM)
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["remember", "foo", "bar"])
+    assert result.exit_code == 0
+    assert calls == [("foo", "bar")]
+


### PR DESCRIPTION
## Summary
- implement `remember` command in `main.py` using `ContextManager.add_fact`
- document CLI memory write in `README.md`
- test new command with Typer `CliRunner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce36de400832bbfb6c593c0c58e14