### PR TITLE
Add plugin context helper

### DIFF
--- a/agent/plugin_context.py
+++ b/agent/plugin_context.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from memory.memory_handler import MemoryHandler
+from agent.goal_tracker import GoalTracker
+from config.settings import settings
+
+
+@dataclass
+class PluginContext:
+    """Lightweight helper exposing memory and goal APIs to plugins."""
+
+    memory_handler: MemoryHandler
+    goal_tracker: GoalTracker
+    thread_id: str = "plugin_thread"
+    identity: str = "plugin_user"
+
+    def add_fact(self, key: str, value: str, identity: Optional[str] = None) -> None:
+        """Store a fact in Axon's memory."""
+        self.memory_handler.add_fact(
+            thread_id=self.thread_id,
+            key=key,
+            value=value,
+            identity=identity or self.identity,
+        )
+
+    def add_goal(self, text: str, identity: Optional[str] = None) -> None:
+        """Record a goal via the GoalTracker."""
+        self.goal_tracker.add_goal(
+            thread_id=self.thread_id,
+            text=text,
+            identity=identity or self.identity,
+        )
+
+
+# Default context used by plugins
+context = PluginContext(
+    memory_handler=MemoryHandler(db_uri=settings.database.postgres_uri),
+    goal_tracker=GoalTracker(db_uri=settings.database.postgres_uri),
+)

--- a/agent/reminder.py
+++ b/agent/reminder.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import threading
-from typing import Callable
 
 from .notifier import Notifier
 

--- a/memory/user_profile.py
+++ b/memory/user_profile.py
@@ -1,6 +1,5 @@
 from typing import Optional
 import psycopg2
-from psycopg2 import sql
 from config.settings import settings
 
 class UserProfileManager:

--- a/plugins/fact_goal.py
+++ b/plugins/fact_goal.py
@@ -1,0 +1,14 @@
+from agent.plugin_loader import plugin
+from agent.plugin_context import context
+
+
+@plugin(
+    name="remember_goal",
+    description="Store a fact and log a goal",
+    usage="remember_goal(key='topic', value='info', goal='Finish project')",
+)
+def remember_goal(key: str, value: str, goal: str) -> str:
+    """Demo plugin that saves a fact then records a goal."""
+    context.add_fact(key, value)
+    context.add_goal(goal)
+    return "ok"

--- a/tests/test_plugin_context.py
+++ b/tests/test_plugin_context.py
@@ -1,0 +1,41 @@
+from agent.plugin_context import PluginContext, context
+from agent.plugin_loader import load_plugins, AVAILABLE_PLUGINS
+
+
+class DummyMemory:
+    def __init__(self):
+        self.add_calls = []
+
+    def add_fact(self, thread_id, key, value, identity=None):
+        self.add_calls.append((thread_id, key, value, identity))
+
+
+class DummyGoals:
+    def __init__(self):
+        self.calls = []
+
+    def add_goal(self, thread_id, text, identity=None):
+        self.calls.append((thread_id, text, identity))
+
+
+def test_context_helpers():
+    mem = DummyMemory()
+    goals = DummyGoals()
+    ctx = PluginContext(memory_handler=mem, goal_tracker=goals, thread_id="t1", identity="bob")
+    ctx.add_fact("k", "v")
+    ctx.add_goal("do it")
+    assert mem.add_calls == [("t1", "k", "v", "bob")]
+    assert goals.calls == [("t1", "do it", "bob")]
+
+
+def test_demo_plugin(monkeypatch):
+    mem = DummyMemory()
+    goals = DummyGoals()
+    monkeypatch.setattr(context, "memory_handler", mem)
+    monkeypatch.setattr(context, "goal_tracker", goals)
+    load_plugins(hot_reload=True)
+    func = AVAILABLE_PLUGINS["remember_goal"].func
+    result = func(key="topic", value="fact", goal="goal text")
+    assert result == "ok"
+    assert mem.add_calls
+    assert goals.calls


### PR DESCRIPTION
## Summary
- expose a `PluginContext` with memory and goal tracker helpers
- create `remember_goal` sample plugin using that context
- add tests for the context and plugin
- clean up unused imports flagged by ruff

## Testing
- `ruff .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce49cb2f8832b8c90c01422e2e319