### PR TITLE
Convert plugins to Qwen tools

### DIFF
--- a/agent/tools/calculator_proxy.py
+++ b/agent/tools/calculator_proxy.py
@@ -1,8 +1,56 @@
 import os
 import requests
 from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
 
 BASE_URL = os.environ.get("CALC_MCP_URL", "http://localhost:9003")
+
+
+@register_tool("calculator")
+class CalculatorProxy(BaseTool):
+    """Perform calculations via MCP."""
+
+    description = "Perform calculations via MCP"
+    parameters = [
+        {
+            "name": "command",
+            "type": "string",
+            "description": "Operation to perform: evaluate or percent",
+            "required": True,
+        },
+        {
+            "name": "expr",
+            "type": "string",
+            "description": "Expression to evaluate",
+        },
+        {
+            "name": "x",
+            "type": "number",
+            "description": "First value for percent",
+        },
+        {
+            "name": "y",
+            "type": "number",
+            "description": "Second value for percent",
+        },
+    ]
+
+    def __init__(self, cfg: Any | None = None):
+        super().__init__(cfg)
+        self.base_url = os.environ.get("CALC_MCP_URL", "http://localhost:9003")
+
+    def call(self, params: Any, **kwargs):
+        args = self._verify_json_format_args(params)
+        command = args["command"]
+        if command == "evaluate":
+            resp = requests.get(f"{self.base_url}/evaluate", params=args)
+        elif command == "percent":
+            resp = requests.get(f"{self.base_url}/percent", params=args)
+        else:
+            return f"Unknown command {command}"
+        resp.raise_for_status()
+        return resp.json()
 
 @plugin(
     name="calculator",
@@ -10,11 +58,6 @@ BASE_URL = os.environ.get("CALC_MCP_URL", "http://localhost:9003")
     usage="calculator(command='evaluate', expr='2+2')"
 )
 def calculator(command: str, **kwargs):
-    if command == "evaluate":
-        resp = requests.get(f"{BASE_URL}/evaluate", params=kwargs)
-    elif command == "percent":
-        resp = requests.get(f"{BASE_URL}/percent", params=kwargs)
-    else:
-        return f"Unknown command {command}"
-    resp.raise_for_status()
-    return resp.json()
+    tool = CalculatorProxy()
+    params = {"command": command, **kwargs}
+    return tool.call(params)

--- a/agent/tools/filesystem_proxy.py
+++ b/agent/tools/filesystem_proxy.py
@@ -1,8 +1,59 @@
 import os
 import requests
 from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
 
 BASE_URL = os.environ.get("FILESYSTEM_MCP_URL", "http://localhost:9001")
+
+
+@register_tool("filesystem")
+class FilesystemProxy(BaseTool):
+    """Interact with the local filesystem via MCP."""
+
+    description = "Interact with local filesystem via MCP"
+    parameters = [
+        {
+            "name": "command",
+            "type": "string",
+            "description": "Operation to perform: list, read, write or exists",
+            "required": True,
+        },
+        {
+            "name": "path",
+            "type": "string",
+            "description": "Filesystem path",
+        },
+        {
+            "name": "content",
+            "type": "string",
+            "description": "Content used when writing files",
+        },
+    ]
+
+    def __init__(self, cfg: Any | None = None):
+        super().__init__(cfg)
+        self.base_url = os.environ.get("FILESYSTEM_MCP_URL", "http://localhost:9001")
+
+    def call(self, params: Any, **kwargs):
+        args = self._verify_json_format_args(params)
+        command = args["command"]
+        path = args.get("path", "")
+        content = args.get("content")
+        if command == "list":
+            resp = requests.get(f"{self.base_url}/list", params={"path": path})
+        elif command == "read":
+            resp = requests.get(f"{self.base_url}/read", params={"path": path})
+        elif command == "write":
+            resp = requests.post(
+                f"{self.base_url}/write", params={"path": path}, json={"content": content or ""}
+            )
+        elif command == "exists":
+            resp = requests.get(f"{self.base_url}/exists", params={"path": path})
+        else:
+            return f"Unknown command {command}"
+        resp.raise_for_status()
+        return resp.json()
 
 @plugin(
     name="filesystem",
@@ -10,15 +61,5 @@ BASE_URL = os.environ.get("FILESYSTEM_MCP_URL", "http://localhost:9001")
     usage="filesystem(command='read', path='file.txt')"
 )
 def filesystem(command: str, path: str = "", content: str | None = None):
-    if command == "list":
-        resp = requests.get(f"{BASE_URL}/list", params={"path": path})
-    elif command == "read":
-        resp = requests.get(f"{BASE_URL}/read", params={"path": path})
-    elif command == "write":
-        resp = requests.post(f"{BASE_URL}/write", params={"path": path}, json={"content": content or ""})
-    elif command == "exists":
-        resp = requests.get(f"{BASE_URL}/exists", params={"path": path})
-    else:
-        return f"Unknown command {command}"
-    resp.raise_for_status()
-    return resp.json()
+    tool = FilesystemProxy()
+    return tool.call({"command": command, "path": path, "content": content})

--- a/agent/tools/markdown_backup_proxy.py
+++ b/agent/tools/markdown_backup_proxy.py
@@ -1,8 +1,62 @@
 import os
 import requests
 from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
 
 BASE_URL = os.environ.get("MARKDOWN_MCP_URL", "http://localhost:9004")
+
+
+@register_tool("markdown_backup")
+class MarkdownBackupProxy(BaseTool):
+    """Save and retrieve markdown notes via MCP."""
+
+    description = "Save and retrieve markdown notes via MCP"
+    parameters = [
+        {
+            "name": "command",
+            "type": "string",
+            "description": "Operation to perform: save, get or search",
+            "required": True,
+        },
+        {
+            "name": "name",
+            "type": "string",
+            "description": "Note name",
+        },
+        {
+            "name": "content",
+            "type": "string",
+            "description": "Markdown content when saving",
+        },
+        {
+            "name": "query",
+            "type": "string",
+            "description": "Search query",
+        },
+    ]
+
+    def __init__(self, cfg: Any | None = None):
+        super().__init__(cfg)
+        self.base_url = os.environ.get("MARKDOWN_MCP_URL", "http://localhost:9004")
+
+    def call(self, params: Any, **kwargs):
+        args = self._verify_json_format_args(params)
+        command = args["command"]
+        if command == "save":
+            resp = requests.post(
+                f"{self.base_url}/save",
+                params={"name": args.get("name")},
+                json={"content": args.get("content", "")},
+            )
+        elif command == "get":
+            resp = requests.get(f"{self.base_url}/get", params={"name": args.get("name")})
+        elif command == "search":
+            resp = requests.get(f"{self.base_url}/search", params={"query": args.get("query", "")})
+        else:
+            return f"Unknown command {command}"
+        resp.raise_for_status()
+        return resp.json()
 
 @plugin(
     name="markdown_backup",
@@ -10,13 +64,6 @@ BASE_URL = os.environ.get("MARKDOWN_MCP_URL", "http://localhost:9004")
     usage="markdown_backup(command='save', name='note', content='text')"
 )
 def markdown_backup(command: str, **kwargs):
-    if command == "save":
-        resp = requests.post(f"{BASE_URL}/save", params={"name": kwargs.get("name")}, json={"content": kwargs.get("content", "")})
-    elif command == "get":
-        resp = requests.get(f"{BASE_URL}/get", params={"name": kwargs.get("name")})
-    elif command == "search":
-        resp = requests.get(f"{BASE_URL}/search", params={"query": kwargs.get("query", "")})
-    else:
-        return f"Unknown command {command}"
-    resp.raise_for_status()
-    return resp.json()
+    tool = MarkdownBackupProxy()
+    kwargs = {"command": command, **kwargs}
+    return tool.call(kwargs)

--- a/agent/tools/time_proxy.py
+++ b/agent/tools/time_proxy.py
@@ -1,8 +1,53 @@
 import os
 import requests
 from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
 
 BASE_URL = os.environ.get("TIME_MCP_URL", "http://localhost:9002")
+
+
+@register_tool("time")
+class TimeProxy(BaseTool):
+    """Access system time via MCP."""
+
+    description = "Access system time via MCP"
+    parameters = [
+        {
+            "name": "command",
+            "type": "string",
+            "description": "Operation to perform: now, timezone or duration",
+            "required": True,
+        },
+        {
+            "name": "start",
+            "type": "string",
+            "description": "Start time for duration command",
+        },
+        {
+            "name": "end",
+            "type": "string",
+            "description": "End time for duration command",
+        },
+    ]
+
+    def __init__(self, cfg: Any | None = None):
+        super().__init__(cfg)
+        self.base_url = os.environ.get("TIME_MCP_URL", "http://localhost:9002")
+
+    def call(self, params: Any, **kwargs):
+        args = self._verify_json_format_args(params)
+        command = args["command"]
+        if command == "now":
+            resp = requests.get(f"{self.base_url}/now")
+        elif command == "timezone":
+            resp = requests.get(f"{self.base_url}/timezone")
+        elif command == "duration":
+            resp = requests.get(f"{self.base_url}/duration", params=args)
+        else:
+            return f"Unknown command {command}"
+        resp.raise_for_status()
+        return resp.json()
 
 @plugin(
     name="time",
@@ -10,13 +55,6 @@ BASE_URL = os.environ.get("TIME_MCP_URL", "http://localhost:9002")
     usage="time(command='now')"
 )
 def time_tool(command: str, **kwargs):
-    if command == "now":
-        resp = requests.get(f"{BASE_URL}/now")
-    elif command == "timezone":
-        resp = requests.get(f"{BASE_URL}/timezone")
-    elif command == "duration":
-        resp = requests.get(f"{BASE_URL}/duration", params=kwargs)
-    else:
-        return f"Unknown command {command}"
-    resp.raise_for_status()
-    return resp.json()
+    tool = TimeProxy()
+    params = {"command": command, **kwargs}
+    return tool.call(params)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,20 +2,24 @@
 
 Axon supports simple Python plugins that can add new commands or actions. Plugins live in the `plugins/` folder and are discovered at startup.
 
-Each plugin defines a function decorated with `@plugin` from `agent.plugin_loader`. Metadata such as name, description and usage are provided to help the agent advertise available skills.
+Plugins are implemented as [Qwen-Agent](https://github.com/QwenLM/Qwen-Agent) tools by subclassing `BaseTool` and registering with `register_tool`.
 
 ```python
-# plugins/echo.py
-from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
 
-@plugin(
-    name="echo",
-    description="Echo back the provided text",
-    usage="echo('hello')"
-)
-def echo(text: str) -> str:
-    return text
+@register_tool("echo")
+class EchoTool(BaseTool):
+    description = "Echo back the provided text"
+    parameters = [
+        {"name": "text", "type": "string", "description": "Text to echo", "required": True}
+    ]
+
+    def call(self, params, **kwargs):
+        args = self._verify_json_format_args(params)
+        return args["text"]
 ```
+
+For backwards compatibility, plugins may still expose a simple function decorated with `@plugin` that calls the tool's `call()` method.
 
 Restart the CLI (`python main.py cli`) or the web backend to load new or changed plugins. During development the loader hot‑reloads modules so edits take effect immediately.
 

--- a/plugins/clipboard_monitor.py
+++ b/plugins/clipboard_monitor.py
@@ -1,5 +1,39 @@
 from agent.plugin_loader import plugin
 import time
+from typing import Any
+from qwen_agent.tools.base import BaseTool, register_tool
+
+
+@register_tool("clipboard_monitor")
+class ClipboardMonitor(BaseTool):
+    """Return clipboard changes detected within the given period."""
+
+    description = "Watch clipboard for updates for a few seconds"
+    parameters = [
+        {
+            "name": "seconds",
+            "type": "integer",
+            "description": "Duration to monitor clipboard",
+            "required": False,
+            "default": 15,
+        }
+    ]
+
+    def call(self, params: Any, **kwargs):
+        args = self._verify_json_format_args(params)
+        seconds = int(args.get("seconds", 15))
+        if not pyperclip or not keyboard:
+            return "pyperclip and keyboard modules required"
+        end = time.time() + seconds
+        last = pyperclip.paste()
+        seen: list[str] = []
+        while time.time() < end:
+            current = pyperclip.paste()
+            if current != last:
+                seen.append(current)
+                last = current
+            time.sleep(0.5)
+        return seen
 
 try:
     import pyperclip
@@ -15,15 +49,5 @@ except Exception:  # pragma: no cover - optional dependency
 )
 def clipboard_monitor(seconds: int = 15):
     """Return clipboard changes detected within the given period."""
-    if not pyperclip or not keyboard:
-        return "pyperclip and keyboard modules required"
-    end = time.time() + seconds
-    last = pyperclip.paste()
-    seen: list[str] = []
-    while time.time() < end:
-        current = pyperclip.paste()
-        if current != last:
-            seen.append(current)
-            last = current
-        time.sleep(0.5)
-    return seen
+    tool = ClipboardMonitor()
+    return tool.call({"seconds": seconds})

--- a/plugins/echo.py
+++ b/plugins/echo.py
@@ -1,6 +1,27 @@
 # axon/plugins/echo.py
 
 from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
+
+
+@register_tool("echo")
+class EchoTool(BaseTool):
+    """Echo back the provided text"""
+
+    description = "Echo back the provided text"
+    parameters = [
+        {
+            "name": "text",
+            "type": "string",
+            "description": "Text to echo back",
+            "required": True,
+        }
+    ]
+
+    def call(self, params: Any, **kwargs) -> str:
+        args = self._verify_json_format_args(params)
+        return args["text"]
 
 @plugin(
     name="echo",
@@ -8,4 +29,5 @@ from agent.plugin_loader import plugin
     usage="echo('hello')"
 )
 def echo(text: str) -> str:
-    return text
+    tool = EchoTool()
+    return tool.call({"text": text})

--- a/plugins/fact_goal.py
+++ b/plugins/fact_goal.py
@@ -1,5 +1,40 @@
 from agent.plugin_loader import plugin
 from agent.plugin_context import context
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
+
+
+@register_tool("remember_goal")
+class RememberGoal(BaseTool):
+    """Store a fact and record a goal."""
+
+    description = "Store a fact and log a goal"
+    parameters = [
+        {
+            "name": "key",
+            "type": "string",
+            "description": "Fact key",
+            "required": True,
+        },
+        {
+            "name": "value",
+            "type": "string",
+            "description": "Fact value",
+            "required": True,
+        },
+        {
+            "name": "goal",
+            "type": "string",
+            "description": "Goal text to record",
+            "required": True,
+        },
+    ]
+
+    def call(self, params: Any, **kwargs) -> str:
+        args = self._verify_json_format_args(params)
+        context.add_fact(args["key"], args["value"])
+        context.add_goal(args["goal"])
+        return "ok"
 
 
 @plugin(
@@ -9,6 +44,5 @@ from agent.plugin_context import context
 )
 def remember_goal(key: str, value: str, goal: str) -> str:
     """Demo plugin that saves a fact then records a goal."""
-    context.add_fact(key, value)
-    context.add_goal(goal)
-    return "ok"
+    tool = RememberGoal()
+    return tool.call({"key": key, "value": value, "goal": goal})

--- a/plugins/system_info.py
+++ b/plugins/system_info.py
@@ -2,6 +2,21 @@
 
 import platform
 from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
+
+
+@register_tool("get_os_version")
+class GetOSVersion(BaseTool):
+    """Return the host operating system version."""
+
+    description = "Return the host operating system version"
+    parameters = []
+
+    def call(self, params: Any, **kwargs) -> str:
+        # No parameters needed, just verify empty input
+        self._verify_json_format_args(params)
+        return f"The current OS is: {platform.system()} {platform.release()}"
 
 @plugin(
     name="get_os_version",
@@ -9,8 +24,7 @@ from agent.plugin_loader import plugin
     usage="get_os_version()"
 )
 def get_os_version():
-    """
-    A simple plugin that returns the current OS version.
-    """
-    return f"The current OS is: {platform.system()} {platform.release()}"
+    """Return the current OS version."""
+    tool = GetOSVersion()
+    return tool.call({})
 


### PR DESCRIPTION
## Summary
- make each plugin a `BaseTool` subclass registered with `register_tool`
- keep existing helper functions but call new tool classes internally
- document new `BaseTool` usage for plugin authors

## Testing
- `pytest tests/test_plugin_context.py::test_demo_plugin -q`
- `pytest tests/test_mcp_handler.py::test_handle_message -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf0d56f7c832bb4380ffc39d53108