### PR TITLE
Use Qwen-Agent assistant for LLM routing

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -1,10 +1,14 @@
 # Customising Models
 
-LLM calls are routed through `agent.llm_router.LLMRouter`. By default the router targets a local Ollama server and falls back to prompting for a cloud model when the input is very long.
+LLM calls are routed through `agent.llm_router.LLMRouter`. The router builds a
+`qwen_agent.agents.Assistant` using the open‑source **Qwen3** model and all
+registered tools. When the input is very long or the local call fails the router
+returns a JSON payload suggesting a cloud model instead.
 
 The default model used by the backend is configured in `config/settings.yaml` under `llm.default_local_model`. Update this value to switch models globally.
 
-To point the router at a different server you can pass the `server_url` when creating `LLMRouter` in `backend/main.py` or set the environment variable `OLLAMA_URL` and modify the code accordingly.
+To change the model you can pass a different model name when creating
+`LLMRouter` in `backend/main.py` or update `settings.llm.default_local_model`.
 
 Example `settings.yaml` snippet:
 

--- a/tests/test_remote_fallback.py
+++ b/tests/test_remote_fallback.py
@@ -10,7 +10,7 @@ def test_suggest_model():
 
 
 def test_llm_router_cloud_prompt_on_long_input():
-    router = LLMRouter(server_url="http://invalid")
+    router = LLMRouter()
     long_msg = "x" * 500
     result = router.get_response(long_msg, model="local")
     data = json.loads(result)


### PR DESCRIPTION
## Summary
- integrate Qwen-Agent in `LLMRouter`
- update the models guide for the new router
- adjust fallback test for new interface

## Testing
- `ruff agent/llm_router.py tests/test_remote_fallback.py docs/models.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf3c5a184832b8ea8ab744c0155ae