### PR TITLE
Improve Qwen3 reasoning config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ tool-calling capabilities. The Qwen-Agent repository includes several usage
 examples such as the **Qwen3 Tool-call Demo** found in
 `examples/assistant_qwen3.py`.
 
+See [docs/models.md](docs/models.md) for instructions on running Qwen3 with
+reasoning enabled and how to pass the recommended `generate_cfg` settings.
+
 ## Roadmap progress
 
 Phase 0 has been completed and the Phase 1 MVP scaffold is implemented. See [phases/roadmap.md](phases/roadmap.md) for upcoming work.

--- a/agent/llm_router.py
+++ b/agent/llm_router.py
@@ -6,6 +6,7 @@ from typing import Any, List, Dict, Iterable
 
 from qwen_agent.agents import Assistant
 from qwen_agent.tools import TOOL_REGISTRY
+from config.settings import settings
 
 from .fallback_prompt import generate_prompt, to_json
 
@@ -26,6 +27,7 @@ class LLMRouter:
             self.assistant = Assistant(
                 function_list=tool_names,
                 llm={"model": self.model, "model_type": "transformers"},
+                generate_cfg=settings.llm.qwen_agent_generate_cfg,
             )
         return self.assistant
 

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -5,3 +5,5 @@ database:
 
 llm:
   default_local_model: "qwen3:8b"
+  qwen_agent_generate_cfg:
+    fncall_prompt_type: "nous"

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ class DatabaseSettings(BaseModel):
 
 class LlmSettings(BaseModel):
     default_local_model: str
+    qwen_agent_generate_cfg: dict | None = None
 
 class AppSettings(BaseModel):
     database: DatabaseSettings

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -5,3 +5,5 @@ database:
 
 llm:
   default_local_model: "qwen3:8b"
+  qwen_agent_generate_cfg:
+    fncall_prompt_type: "nous"

--- a/docs/models.md
+++ b/docs/models.md
@@ -19,3 +19,27 @@ llm:
 
 Restart the backend after changing settings so the new model is loaded.
 
+## Launching Qwen3 with reasoning
+
+When running Qwen3 locally (via Ollama or any OpenAI‑compatible API) the
+Qwen-Agent README recommends enabling reasoning mode and selecting the "nous"
+tool-call prompt template. Start the model with `--enable-reasoning` and choose
+the DeepSeek parser:
+
+```bash
+ollama serve
+ollama run qwen3:8b --enable-reasoning --reasoning-parser deepseek_r1
+```
+
+Pass the prompt template through `generate_cfg` when creating the assistant.
+`config/settings.yaml` includes an example:
+
+```yaml
+llm:
+  default_local_model: "qwen3:8b"
+  qwen_agent_generate_cfg:
+    fncall_prompt_type: "nous"
+```
+
+`LLMRouter` automatically forwards this dictionary to `qwen_agent.agents.Assistant`.
+


### PR DESCRIPTION
## Summary
- add optional `qwen_agent_generate_cfg` settings field
- pass this dictionary to `Assistant` when creating the LLM router
- document how to launch Qwen3 with reasoning and set `fncall_prompt_type`
- link to model docs from README

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfb5ea974832bbee7f969865881ab