### PR TITLE
Fix timezone-aware datetime

### DIFF
--- a/mcp_servers/time_server.py
+++ b/mcp_servers/time_server.py
@@ -1,12 +1,12 @@
 from fastapi import FastAPI
-from datetime import datetime
+from datetime import datetime, UTC
 import time
 
 app = FastAPI()
 
 @app.get("/now")
 def get_now():
-    return {"timestamp": datetime.utcnow().isoformat()}
+    return {"timestamp": datetime.now(UTC).isoformat()}
 
 @app.get("/timezone")
 def get_timezone():

--- a/poetry.lock
+++ b/poetry.lock
@@ -5547,6 +5547,21 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -6036,6 +6051,18 @@ files = [
     {file = "ruff-0.3.7-py3-none-win_amd64.whl", hash = "sha256:5ef0e501e1e39f35e03c2acb1d1238c595b8bb36cf7a170e7c1df1b73da00e74"},
     {file = "ruff-0.3.7-py3-none-win_arm64.whl", hash = "sha256:789e144f6dc7019d1f92a812891c645274ed08af6037d11fc65fcbc183b7d59f"},
     {file = "ruff-0.3.7.tar.gz", hash = "sha256:d5c1aebee5162c2226784800ae031f660c350e7a3402c4d1f8ea4e97e232e3ba"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -6665,4 +6692,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "fdba761c5ac3cddbc0b98fc9446dd8a57858399e726442cf377c40ef8713f70b"
+content-hash = "f08bb9624ad296cf91f09794903e5d4d106fbb61490a6e4b77da6b428e5749b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pyperclip = "^1.8.2"
 keyboard = "^0.13.5"
 plyer = "^2.1.0"
 qwen-agent = "0.0.27"
+python-dateutil = "^2.9.0.post0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.2"


### PR DESCRIPTION
## Summary
- switch `datetime.utcnow()` to `datetime.now(UTC)` in the time server
- add `python-dateutil` dependency for tests

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8974ada4832bb2bb814d3082e3fd