### PR TITLE
Validate MCP servers and proxy tools

### DIFF
--- a/tests/test_proxy_tools.py
+++ b/tests/test_proxy_tools.py
@@ -1,0 +1,67 @@
+from fastapi.testclient import TestClient
+from mcp_servers.filesystem_server import app as fs_app
+from mcp_servers.time_server import app as time_app
+from mcp_servers.calculator_server import app as calc_app
+from mcp_servers.markdown_backup_server import app as md_app
+from agent.tools.filesystem_proxy import FilesystemProxy
+from agent.tools.time_proxy import TimeProxy
+from agent.tools.calculator_proxy import CalculatorProxy
+from agent.tools.markdown_backup_proxy import MarkdownBackupProxy
+import requests
+
+
+def make_mock(client: TestClient):
+    def get(url, params=None, **kwargs):
+        path = url.split("/")[-1]
+        return client.get(f"/{path}", params=params)
+
+    def post(url, params=None, json=None, **kwargs):
+        path = url.split("/")[-1]
+        return client.post(f"/{path}", params=params, json=json)
+
+    return get, post
+
+
+def test_filesystem_proxy(monkeypatch, tmp_path):
+    client = TestClient(fs_app)
+    get, post = make_mock(client)
+    monkeypatch.setattr(requests, "get", get)
+    monkeypatch.setattr(requests, "post", post)
+
+    proxy = FilesystemProxy()
+    file_path = tmp_path / "note.txt"
+    result = proxy.call({"command": "write", "path": str(file_path), "content": "hi"})
+    assert result["status"] == "ok"
+    result = proxy.call({"command": "read", "path": str(file_path)})
+    assert result["content"] == "hi"
+
+
+def test_time_proxy(monkeypatch):
+    client = TestClient(time_app)
+    get, _ = make_mock(client)
+    monkeypatch.setattr(requests, "get", get)
+    proxy = TimeProxy()
+    result = proxy.call({"command": "duration", "start": 1, "end": 4})
+    assert result["seconds"] == 3
+
+
+def test_calculator_proxy(monkeypatch):
+    client = TestClient(calc_app)
+    get, _ = make_mock(client)
+    monkeypatch.setattr(requests, "get", get)
+    proxy = CalculatorProxy()
+    result = proxy.call({"command": "evaluate", "expr": "2+3"})
+    assert result["result"] == 5
+
+
+def test_markdown_backup_proxy(monkeypatch, tmp_path):
+    # ensure markdown dir uses tmp
+    client = TestClient(md_app)
+    get, post = make_mock(client)
+    monkeypatch.setattr(requests, "get", get)
+    monkeypatch.setattr(requests, "post", post)
+    proxy = MarkdownBackupProxy()
+    result = proxy.call({"command": "save", "name": "n1", "content": "hello"})
+    assert result["status"] == "ok"
+    result = proxy.call({"command": "get", "name": "n1"})
+    assert result["content"] == "hello"


### PR DESCRIPTION
## Summary
- add integration tests ensuring that each MCP proxy returns proper JSON
- verify MCP FastAPI servers start and pass their endpoint tests

## Testing
- `pytest tests/test_filesystem_server.py tests/test_time_server.py tests/test_calculator_server.py tests/test_markdown_backup_server.py tests/test_proxy_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef8b070e8832baf31dd675031d3c3