### PR TITLE
Implement MCP router and memory tagging

### DIFF
--- a/agent/mcp_handler.py
+++ b/agent/mcp_handler.py
@@ -55,4 +55,5 @@ class MCPHandler:
         if tool_name not in AVAILABLE_PLUGINS:
             raise ValueError(f"Unknown tool: {tool_name}")
         plugin_info = AVAILABLE_PLUGINS[tool_name]
-        return plugin_info.func(**args)
+        output = plugin_info.func(**args)
+        return {"source": tool_name, "output": output}

--- a/agent/mcp_router.py
+++ b/agent/mcp_router.py
@@ -1,0 +1,69 @@
+import os
+import json
+import yaml
+import subprocess
+import requests
+from typing import Any, Dict, List, Optional
+
+
+class MCPRouter:
+    """Registry and transport handler for MCP tools."""
+
+    def __init__(self, config_path: str = "config/mcp_servers.yaml") -> None:
+        self.tools: Dict[str, Dict[str, Any]] = {}
+        if os.path.exists(config_path):
+            self.load_config(config_path)
+
+    def load_config(self, path: str) -> None:
+        """Load tool info from a YAML file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or []
+        if isinstance(data, dict):
+            servers = data.get("servers", [])
+        else:
+            servers = data
+        for entry in servers:
+            name = entry.get("name")
+            if name:
+                self.tools[name] = entry
+
+    def list_tools(self) -> List[str]:
+        return list(self.tools.keys())
+
+    def get_tool(self, name: str) -> Optional[Dict[str, Any]]:
+        return self.tools.get(name)
+
+    def call(self, name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Send a payload to the given tool using its configured transport."""
+        info = self.get_tool(name)
+        if not info:
+            raise ValueError(f"Unknown tool: {name}")
+        transport = info.get("transport")
+        if transport == "http":
+            url = str(info["url"]).rstrip("/")
+            command = payload.get("command")
+            if command:
+                resp = requests.get(f"{url}/{command}", params=payload)
+            else:
+                resp = requests.post(url, json=payload)
+            resp.raise_for_status()
+            return resp.json()
+        if transport == "stdio":
+            cmd = info["command"]
+            proc = subprocess.Popen(
+                cmd,
+                shell=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            stdout, stderr = proc.communicate(json.dumps(payload))
+            if proc.returncode != 0:
+                raise RuntimeError(stderr.strip())
+            return json.loads(stdout.strip() or "{}")
+        raise ValueError(f"Unsupported transport: {transport}")
+
+
+# Global router instance loaded from default config
+mcp_router = MCPRouter()

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from agent.pasteback_handler import PastebackHandler
 from memory.user_profile import UserProfileManager
 import re
 import logging
+import time
 
 # --- NEW: Configure Logging ---
 logging.basicConfig(
@@ -191,7 +192,15 @@ async def websocket_endpoint(websocket: WebSocket):
             elif isinstance(mcp_data, dict) and mcp_handler.parse_message(mcp_data):
                 try:
                     result = mcp_handler.handle_message(mcp_data)
-                    response_message = json.dumps(result)
+                    response_message = json.dumps(result["output"])
+                    ts = int(time.time())
+                    memory_handler.add_fact(
+                        thread_id,
+                        f"{result['source']}_{ts}",
+                        json.dumps(result["output"]),
+                        identity=result["source"],
+                        tags=[f"source:{result['source']}"]
+                    )
                 except Exception as e:
                     response_message = f"MCP error: {e}"
             elif remember_match:

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -1,0 +1,9 @@
+- name: filesystem
+  transport: http
+  url: http://localhost:9001
+- name: time
+  transport: http
+  url: http://localhost:9002
+- name: calculator
+  transport: http
+  url: http://localhost:9003

--- a/tests/test_mcp_handler.py
+++ b/tests/test_mcp_handler.py
@@ -14,4 +14,5 @@ def test_handle_message(mock_get):
     handler = MCPHandler()
     msg = handler.generate_message('calculator', {'command': 'evaluate', 'expr': '1+1'})
     result = handler.handle_message(msg)
-    assert result['result'] == 2
+    assert result['source'] == 'calculator'
+    assert result['output']['result'] == 2

--- a/tests/test_mcp_router.py
+++ b/tests/test_mcp_router.py
@@ -1,0 +1,34 @@
+from agent.mcp_router import MCPRouter
+from starlette.testclient import TestClient
+from mcp_servers.time_server import app as time_app
+
+
+def test_load_and_list(tmp_path):
+    config = tmp_path / "servers.yaml"
+    config.write_text(
+        """
+- name: time
+  transport: http
+  url: http://testserver
+"""
+    )
+    router = MCPRouter(config_path=str(config))
+    assert router.list_tools() == ["time"]
+    info = router.get_tool("time")
+    assert info["url"] == "http://testserver"
+
+
+def test_call_http(monkeypatch):
+    client = TestClient(time_app)
+
+    def fake_get(url, params=None, **kwargs):
+        path = url.split("/")[-1]
+        return client.get(f"/{path}", params=params)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    router = MCPRouter()
+    router.tools = {"time": {"transport": "http", "url": "http://unused"}}
+    result = router.call("time", {"command": "now"})
+    assert "timestamp" in result
+


### PR DESCRIPTION
## Summary
- add MCP server config YAML
- implement `MCPRouter` for routing calls
- tag MCPHandler responses with tool source
- store tool results in memory with origin in websocket handler
- test new MCPRouter and updated MCPHandler

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f01de8c8c832b9d80f76e121e3831