### PR TITLE
Add MCP router listing and API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from agent.llm_router import LLMRouter
 from agent.goal_tracker import GoalTracker
 from agent.plugin_loader import load_plugins, AVAILABLE_PLUGINS
 from agent.mcp_handler import MCPHandler
+from agent.mcp_router import mcp_router
 from agent.pasteback_handler import PastebackHandler
 from memory.user_profile import UserProfileManager
 import re
@@ -50,6 +51,16 @@ def shutdown_event():
 @app.get("/")
 async def read_root():
     return {"message": "Axon backend is running and connected to memory."}
+
+
+@app.get("/mcp/tools")
+async def list_mcp_tools():
+    tools = {}
+    for name in mcp_router.list_tools():
+        tools[name] = {
+            "available": mcp_router.check_tool(name)
+        }
+    return {"tools": tools}
 
 
 @app.get("/memory/{thread_id}")

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import typer
 import uvicorn
 import asyncio
 from agent.plugin_loader import load_plugins, AVAILABLE_PLUGINS
+from agent.mcp_router import MCPRouter
 from memory.user_profile import UserProfileManager
 from agent.reminder import ReminderManager
 from agent.context_manager import ContextManager
@@ -108,6 +109,15 @@ def remember(topic: str, fact: str, thread_id: str = "cli_thread", identity: str
     cm = ContextManager(thread_id=thread_id, identity=identity)
     cm.add_fact(topic, fact)
     print(f"Remembered '{topic}' = '{fact}'.")
+
+
+@app.command("mcp-tools")
+def list_mcp_tools(config: str = "config/mcp_servers.yaml") -> None:
+    """List registered MCP tools and check connectivity."""
+    router = MCPRouter(config)
+    for name in router.list_tools():
+        status = "ok" if router.check_tool(name) else "unreachable"
+        print(f"{name}: {status}")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_mcp_list.py
+++ b/tests/test_cli_mcp_list.py
@@ -1,0 +1,25 @@
+from typer.testing import CliRunner
+import main
+from unittest.mock import MagicMock
+
+
+def test_mcp_tools_cli(monkeypatch, tmp_path):
+    cfg = tmp_path / "servers.yaml"
+    cfg.write_text(
+        """
+- name: echo
+  transport: http
+  url: http://testserver
+"""
+    )
+
+    runner = CliRunner()
+
+
+    class DummyResp:
+        status_code = 200
+    monkeypatch.setattr("agent.mcp_router.requests.get", MagicMock(return_value=DummyResp()))
+
+    result = runner.invoke(main.app, ["mcp-tools", "--config", str(cfg)])
+    assert result.exit_code == 0
+    assert "echo" in result.stdout

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+from agent.mcp_router import mcp_router
+
+
+def test_list_mcp_tools_endpoint(monkeypatch):
+    mcp_router.tools = {"echo": {"transport": "http", "url": "http://testserver"}}
+
+    class DummyResp:
+        status_code = 200
+    monkeypatch.setattr("agent.mcp_router.requests.get", lambda url, timeout=2: DummyResp())
+
+    client = TestClient(app)
+    resp = client.get("/mcp/tools")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tools"]["echo"]["available"] is True


### PR DESCRIPTION
## Summary
- implement connectivity checks in `MCPRouter`
- expose CLI command `mcp-tools` to list registered tools
- add `/mcp/tools` endpoint in backend for tool discovery
- test new CLI command and API endpoint

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4dcd2d54832bab86abdd16509c51