### PR TITLE
Normalize MCP responses into chat memory

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -208,9 +208,12 @@ async def websocket_endpoint(websocket: WebSocket):
                     memory_handler.add_fact(
                         thread_id,
                         f"{result['source']}_{ts}",
-                        json.dumps(result["output"]),
+                        result["summary"],
                         identity=result["source"],
-                        tags=[f"source:{result['source']}"]
+                        tags=[
+                            f"source:{result['source']}",
+                            f"confidence:{result['confidence']:.2f}",
+                        ],
                     )
                 except Exception as e:
                     response_message = f"MCP error: {e}"

--- a/tests/test_mcp_handler.py
+++ b/tests/test_mcp_handler.py
@@ -16,3 +16,5 @@ def test_handle_message(mock_get):
     result = handler.handle_message(msg)
     assert result['source'] == 'calculator'
     assert result['output']['result'] == 2
+    assert 'summary' in result
+    assert result['confidence'] >= 0.5


### PR DESCRIPTION
## Summary
- normalize tool output in `MCPHandler`
- tag summarized MCP results with source and confidence in the backend
- test new MCP normalization behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f68364b40832b9b0a34ac68f6bbb6