### PR TITLE
Add documentation MCP server

### DIFF
--- a/agent/tools/docs_proxy.py
+++ b/agent/tools/docs_proxy.py
@@ -1,0 +1,42 @@
+import os
+import requests
+from agent.plugin_loader import plugin
+from qwen_agent.tools.base import BaseTool, register_tool
+from typing import Any
+
+BASE_URL = os.environ.get("DOCS_MCP_URL", "http://localhost:9006")
+
+
+@register_tool("docs")
+class DocsProxy(BaseTool):
+    """Retrieve Python documentation via MCP."""
+
+    description = "Retrieve Python documentation via MCP"
+    parameters = [
+        {
+            "name": "topic",
+            "type": "string",
+            "description": "Python topic or module name",
+            "required": True,
+        }
+    ]
+
+    def __init__(self, cfg: Any | None = None):
+        super().__init__(cfg)
+        self.base_url = os.environ.get("DOCS_MCP_URL", "http://localhost:9006")
+
+    def call(self, params: Any, **kwargs):
+        args = self._verify_json_format_args(params)
+        resp = requests.get(f"{self.base_url}/get", params={"topic": args["topic"]})
+        resp.raise_for_status()
+        return resp.json()
+
+
+@plugin(
+    name="docs",
+    description="Retrieve Python documentation via MCP",
+    usage="docs(topic='asyncio')",
+)
+def docs(topic: str):
+    tool = DocsProxy()
+    return tool.call({"topic": topic})

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -13,3 +13,6 @@
 - name: github
   transport: http
   url: http://localhost:9005
+- name: docs
+  transport: http
+  url: http://localhost:9006

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -15,6 +15,7 @@ This launches the following services on localhost:
 - **Calculator** – `http://localhost:9003`
 - **Markdown Backup** – `http://localhost:9004`
 - **GitHub** – `http://localhost:9005` (basic repo access)
+- **Docs** – `http://localhost:9006` (Python documentation)
 
 The backend expects these URLs via environment variables when running in containers. They can be customised in `docker-compose.yml` or your shell environment.
 

--- a/mcp_servers/__main__.py
+++ b/mcp_servers/__main__.py
@@ -5,6 +5,7 @@ from .time_server import app as time_app
 from .calculator_server import app as calc_app
 from .markdown_backup_server import app as md_app
 from .github_server import app as gh_app
+from .docs_server import app as docs_app
 
 SERVERS = [
     (fs_app, 9001),
@@ -12,6 +13,7 @@ SERVERS = [
     (calc_app, 9003),
     (md_app, 9004),
     (gh_app, 9005),
+    (docs_app, 9006),
 ]
 
 def run(app, port):

--- a/mcp_servers/docs_server.py
+++ b/mcp_servers/docs_server.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI, HTTPException
+import pydoc
+
+app = FastAPI()
+
+@app.get("/get")
+def get_doc(topic: str):
+    """Return documentation for a Python topic."""
+    try:
+        text = pydoc.render_doc(topic)
+    except ImportError:
+        raise HTTPException(status_code=404, detail="topic not found")
+    return {"content": text}

--- a/plugins/system_info.py
+++ b/plugins/system_info.py
@@ -11,7 +11,7 @@ class GetOSVersion(BaseTool):
     """Return the host operating system version."""
 
     description = "Return the host operating system version"
-    parameters = []
+    parameters: list[Any] = []
 
     def call(self, params: Any, **kwargs) -> str:
         # No parameters needed, just verify empty input

--- a/tests/test_docs_proxy.py
+++ b/tests/test_docs_proxy.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from mcp_servers.docs_server import app as docs_app
+from agent.tools.docs_proxy import DocsProxy
+import requests
+
+
+def make_mock(client: TestClient):
+    def get(url, params=None, **kwargs):
+        path = url.split("/")[-1]
+        return client.get(f"/{path}", params=params)
+
+    return get
+
+
+def test_docs_proxy(monkeypatch):
+    client = TestClient(docs_app)
+    monkeypatch.setattr(requests, "get", make_mock(client))
+    proxy = DocsProxy()
+    result = proxy.call({"topic": "math"})
+    assert "math" in result["content"]

--- a/tests/test_docs_server.py
+++ b/tests/test_docs_server.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from mcp_servers.docs_server import app
+
+client = TestClient(app)
+
+
+def test_get_doc():
+    resp = client.get("/get", params={"topic": "math"})
+    assert resp.status_code == 200
+    assert "math" in resp.json()["content"]


### PR DESCRIPTION
## Summary
- add docs MCP server and proxy
- include the new service in MCP server startup list
- document the docs service in setup instructions
- support mypy typing for system_info plugin
- test docs server and proxy

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880510baec8832b8797d9f1ac99951c