### PR TITLE
Update roadmap docs and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,7 @@ jobs:
         # We need to install stubs for libraries that don't have inline types
         poetry run pip install types-pyyaml
         poetry run mypy .
+
+    - name: Run tests
+      run: |
+        poetry run pytest -q

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ reasoning enabled and how to pass the recommended `generate_cfg` settings.
 
 ## Roadmap progress
 
-Phases 0 through 3.9 have been completed. Core MCP servers are stable and the GitHub service is partially implemented. See [phases/roadmap.md](phases/roadmap.md) for progress on additional secondary servers.
+Phases 0 through 3.9 are complete. Phase 4 is currently in progress with manual cloud prompting and calendar features. See [phases/roadmap.md](phases/roadmap.md) for the latest status of each phase.
 

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -7,3 +7,7 @@ llm:
   default_local_model: "qwen3:8b"
   qwen_agent_generate_cfg:
     fncall_prompt_type: "nous"
+
+app:
+  mcp_mode: false
+  mcp_log_path: "mcp_traffic.json"

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,6 +16,7 @@ class LlmSettings(BaseModel):
 class AppSettings(BaseModel):
     database: DatabaseSettings
     llm: LlmSettings
+    app: dict | None = None
 
 def load_settings() -> AppSettings:
     """Loads settings from the YAML file and validates them."""

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -7,3 +7,7 @@ llm:
   default_local_model: "qwen3:8b"
   qwen_agent_generate_cfg:
     fncall_prompt_type: "nous"
+
+app:
+  mcp_mode: false
+  mcp_log_path: "mcp_traffic.json"

--- a/memory/memory_handler.py
+++ b/memory/memory_handler.py
@@ -68,6 +68,7 @@ class MemoryHandler:
         key: str,
         value: str,
         identity: Optional[str] = None,
+        domain: Optional[str] = None,
         tags: Optional[Iterable[str]] = None,
     ) -> None:
         """
@@ -77,6 +78,9 @@ class MemoryHandler:
             print("No database connection.")
             return
 
+        tags = list(tags) if tags else []
+        if domain:
+            tags.append(domain)
         tags_str = ",".join(tags) if tags else None
         with self.conn.cursor() as cur:
             query = sql.SQL(
@@ -113,7 +117,7 @@ class MemoryHandler:
             return (value, ident) if include_identity else value
 
     def list_facts(
-        self, thread_id: str, tag: Optional[str] = None
+        self, thread_id: str, tag: Optional[str] = None, domain: Optional[str] = None
     ) -> list[tuple[str, str, str | None, bool, list[str]]]:
         """Returns all facts for a thread including lock state and tags.
 
@@ -131,6 +135,9 @@ class MemoryHandler:
             if tag:
                 query += " AND tags ILIKE %s"
                 params.append(f"%{tag}%")
+            if domain:
+                query += " AND tags ILIKE %s"
+                params.append(f"%{domain}%")
             cur.execute(query, params)
             rows = cur.fetchall()
             result = []
@@ -145,10 +152,14 @@ class MemoryHandler:
         key: str,
         value: str,
         identity: Optional[str] = None,
+        domain: Optional[str] = None,
         tags: Optional[Iterable[str]] = None,
     ) -> None:
         if not self.conn:
             return
+        tags = list(tags) if tags else []
+        if domain:
+            tags.append(domain)
         tags_str = ",".join(tags) if tags else None
         with self.conn.cursor() as cur:
             cur.execute(

--- a/memory/preload.py
+++ b/memory/preload.py
@@ -21,6 +21,7 @@ def preload(memory_handler: MemoryHandler, path: str = "data/initial_memory.yaml
             key=fact.get("key"),
             value=fact.get("value"),
             identity=fact.get("identity"),
+            tags=[fact.get("domain")] if fact.get("domain") else None,
         )
 
     for i, message in enumerate(data.get("mcp_messages", []), start=1):

--- a/phases/axon_phase_1_dev_roadmap.md
+++ b/phases/axon_phase_1_dev_roadmap.md
@@ -72,7 +72,7 @@ memory:
 
 **Optional:**
 
-- Add TUI wrapper for CLI later
+- Implement TUI CLI using the Textual library
 
 ---
 
@@ -143,7 +143,7 @@ qdrant:
 
 **Optional:**
 
-- Add hybrid scoring (recency + similarity)
+- Add hybrid scoring (recency + similarity) and expose a confidence metric in `LLMRouter`
 
 ---
 
@@ -198,8 +198,8 @@ qdrant:
 
 **Optional:**
 
-- Add `mcp_mode: true` toggle in settings
-- Log all MCP-formatted entries to a JSON file
+- Introduce `mcp_mode` option in `settings.yaml`
+- Log all MCP-formatted traffic to a JSON file
 
 ---
 
@@ -225,7 +225,7 @@ qdrant:
 
 **Optional:**
 
-- Add preload options by identity (e.g. “Cary”) or domain
+- Extend preload entries for identity or domain-specific facts
 
 ---
 
@@ -247,8 +247,8 @@ qdrant:
 
 **Optional:**
 
-- Rate limiting
-- Auth later
+- Implement rate limiting
+- Optional authentication hooks
 
 ---
 
@@ -269,7 +269,7 @@ qdrant:
 **Optional:**
 
 - Memory editing panel
-- Model selector dropdown
+- Model selector dropdown in the UI
 
 ---
 

--- a/phases/axon_phase_2_dev_roadmap.md
+++ b/phases/axon_phase_2_dev_roadmap.md
@@ -40,7 +40,7 @@ memory:
 
 **Optional:**
 
-- Add per-domain scoping (e.g., "work", "personal")
+- Introduce domain scoping (e.g., "work", "personal")
 
 ---
 
@@ -64,7 +64,7 @@ memory:
 
 **Optional:**
 
-- Support mass delete by context
+- Support mass deletion endpoints by context or domain
 
 ---
 
@@ -92,7 +92,7 @@ memory:
 
 **Optional:**
 
-- Hot-reload plugins while running
+- Hot-reload plugins via CLI command
 
 ---
 
@@ -120,7 +120,7 @@ plugins:
 
 **Optional:**
 
-- Add permission scoping (per-plugin)
+- Add permission scoping for plugins
 
 ---
 
@@ -145,7 +145,7 @@ plugins:
 
 **Optional:**
 
-- Add priority and deadline fields
+- Add priority and deadline fields to goals
 
 ---
 
@@ -170,7 +170,7 @@ plugins:
 
 **Optional:**
 
-- Add option to re-prompt user about old ideas
+- Periodic prompts for deferred goals
 
 ---
 
@@ -197,7 +197,7 @@ identity_tracking: true
 
 **Optional:**
 
-- Add speaker embedding matching (future ML enhancement)
+- Optional speaker-embedding logic
 
 ---
 

--- a/phases/axon_phase_3_dev_roadmap.md
+++ b/phases/axon_phase_3_dev_roadmap.md
@@ -69,7 +69,7 @@ Axon will:
 
 **Optional:**
 
-- Use to annotate memory creation times
+ - Annotate new memory entries with timestamps
 
 ---
 
@@ -121,7 +121,7 @@ Axon will:
 
 **Optional:**
 
-- Sync notes into vector DB for RAG-style hybrid retrieval
+ - Synchronize markdown notes with Qdrant for retrieval
 
 ---
 
@@ -146,7 +146,7 @@ Axon will:
 
 **Optional:**
 
-- Future plugin: auto-commit fixes
+ - Auto-commit patches via plugin
 
 **Status:** DONE
 
@@ -166,7 +166,7 @@ Axon will:
 
 **Optional:**
 
-- Attach source links to memory
+ - Capture documentation source URLs
 
 **Status:** DONE
 
@@ -186,7 +186,7 @@ Axon will:
 
 **Optional:**
 
-- Generate charts inline in frontend
+ - Render query results as charts in the UI
 
 **Status:** In Progress – CSV query server implemented
 
@@ -222,7 +222,7 @@ Axon will:
 
 **Optional:**
 
-- Add latency and failure metrics
+ - Record MCP latency and failure metrics in the router
 
 **Status:** DONE
 

--- a/phases/axon_phase_4_dev_roadmap.md
+++ b/phases/axon_phase_4_dev_roadmap.md
@@ -63,7 +63,7 @@ Cloud LLMs are **never called automatically**. Instead, Axon:
 
 **Optional:**
 
-- Paste handler tags response with `source: gpt` or `claude`
+ - Tag pasted responses with `source:gpt` or `source:claude`
 
 ---
 
@@ -131,7 +131,7 @@ Cloud LLMs are **never called automatically**. Instead, Axon:
 
 **Optional:**
 
-- Fuzzy matching like "next Thursday"
+ - Natural-language date parsing such as "next Thursday"
 
 ---
 
@@ -153,13 +153,13 @@ Cloud LLMs are **never called automatically**. Instead, Axon:
 
 **Optional:**
 
-- Text-to-speech or audio chime
+ - Provide text-to-speech or audio notifications
 
 ---
 
 ### 4.7 – External Calendar Export (Optional)
 
-**Description:** Export reminders to `.ics` or CalDAV-compatible feed
+**Description:** Implement `calendar_exporter.py` to generate `.ics` files or a CalDAV-compatible feed
 
 **File(s):**
 

--- a/phases/roadmap.md
+++ b/phases/roadmap.md
@@ -28,6 +28,14 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 - [x] Docker Compose: Postgres + Qdrant + backend + frontend
 - [x] CI: GitHub Actions with mypy + ruff checks
 
+### Phase 1 Enhancements (Planned)
+- [ ] TUI-based CLI interface
+- [ ] Hybrid vector scoring and LLM confidence metrics
+- [ ] `mcp_mode` setting and JSON traffic logs
+- [ ] Domain-aware preload entries
+- [ ] Backend rate limiting and optional auth
+- [ ] Model selector dropdown in the UI
+
 ---
 
 ## 🧠 Phase 2: Memory & Plugin Enrichment
@@ -39,6 +47,14 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 - [x] Structured long-term goal tracking
 - [x] Manual note tagging + identity recognition
 - [x] Add support for CLI input memory injection
+
+### Phase 2 Improvements (Planned)
+- [ ] Domain scoping in memory tables and API
+- [ ] Mass deletion endpoints and CLI plugin reload
+- [ ] Permission scoping for plugins
+- [ ] Goal priority and deadline fields
+- [ ] Periodic prompts for deferred goals
+- [ ] Optional speaker-embedding logic
 
 ---
 
@@ -57,6 +73,13 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 - [x] **Text2SQL + Antvis**: structured querying and visualization *(basic CSV query server implemented)*
 - [x] **WolframAlpha / Prolog / Logic MCPs** (optional advanced logic)
 
+### Phase 3 Additions (Planned)
+- [ ] Timestamp new memory entries via Time MCP
+- [ ] Sync markdown notes with Qdrant
+- [ ] Auto-commit patches via GitHub tooling
+- [ ] Capture documentation source URLs and show charts
+- [ ] Record MCP latency/failure metrics
+
 ---
 
 ## ☁️ Phase 4: Remote Model & API Tooling (Optional)
@@ -66,6 +89,12 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 - [ ] UI support for paste-back workflow
 - [ ] Tool/plugin to watch clipboard and auto-insert output
 - [ ] Optional fallback through hosted proxy (manual consent only)
+
+### Phase 4 Extensions (Planned)
+- [ ] Tag pasted responses with source annotations
+- [ ] Natural-language date parsing for reminders
+- [ ] Text-to-speech or audio notifications
+- [ ] Calendar export utility with `.ics` generation
 
 ---
 


### PR DESCRIPTION
## Summary
- document Phase 1–4 remaining tasks in `phases/roadmap.md`
- update phase docs with new enhancements and options
- extend preload tool and memory handler for domain tags
- add `mcp_mode` config sample
- run pytest in CI
- tweak README roadmap note

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d1e62674832b82ea7575dff3b9e7