### PR TITLE
Fix git config in tests

### DIFF
--- a/tests/test_github_server.py
+++ b/tests/test_github_server.py
@@ -9,6 +9,11 @@ def test_list_and_read(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "-C", str(repo), "init"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
     file = repo / "README.md"
     file.write_text("hello", encoding="utf-8")
     subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)

--- a/tests/test_proxy_tools.py
+++ b/tests/test_proxy_tools.py
@@ -74,6 +74,11 @@ def test_github_proxy(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "-C", str(repo), "init"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
     file = repo / "file.txt"
     file.write_text("data", encoding="utf-8")
     subprocess.run(["git", "-C", str(repo), "add", "file.txt"], check=True)


### PR DESCRIPTION
### Summary
Configure git user information in unit tests that initialize repositories.

### Problem & Evidence
- Tests `test_list_and_read` and `test_github_proxy` failed on CI because `git commit` returned exit 128 due to missing user identity.
- See CI log snippet: `fatal: empty ident name ... not allowed`.

### Solution & Alternatives
- Added repo-level `git config user.email` and `user.name` before making commits.
- Alternative was setting global config, but configuring per-test keeps environment isolated.

### Verification
```bash
make verify                     # → 40 passed
poetry run pytest tests/test_github_server.py::test_list_and_read tests/test_proxy_tools.py::test_github_proxy -q  # → 2 passed
```

### Manual Testing
- [x] Tested happy path: both affected tests pass locally.
- [ ] Tested error cases
- [x] Verified no regressions: other tests run via `make verify`.

### Deployment Notes
- **Risk level:** low
- **Rollback plan:** revert commit if issues arise
- **Breaking changes:** None
- **Dependencies:** None

### Skipped/Blocked
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68810559c950832ba80b9e83c1c5ed58