### PR TITLE
Fix datetime UTC support for Python 3.10

### DIFF
--- a/mcp_servers/time_server.py
+++ b/mcp_servers/time_server.py
@@ -1,16 +1,24 @@
 from fastapi import FastAPI
-from datetime import datetime, UTC
+from datetime import datetime, timezone
+
+try:  # Python 3.11+
+    from datetime import UTC  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - for Python <3.11
+    UTC = timezone.utc
 import time
 
 app = FastAPI()
+
 
 @app.get("/now")
 def get_now():
     return {"timestamp": datetime.now(UTC).isoformat()}
 
+
 @app.get("/timezone")
 def get_timezone():
     return {"timezone": time.tzname[0]}
+
 
 @app.get("/duration")
 def duration_between(start: float, end: float):


### PR DESCRIPTION
## Summary
- add compatibility layer for older Python versions that don't have `datetime.UTC`

## Reasoning
The CI run failed with a mypy error:
```
mcp_servers/time_server.py:2: error: Module "datetime" has no attribute "UTC"  [attr-defined]
```
Python 3.10 lacks the `datetime.UTC` constant. Falling back to `timezone.utc` resolves the type error and keeps behaviour the same.

## Testing
- `make verify`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688108c7b69c832b8a83c0ca8bc3962c