### PR TITLE
Add domain scoping to memory tables

### DIFF
--- a/agent/calendar_exporter.py
+++ b/agent/calendar_exporter.py
@@ -11,7 +11,10 @@ from icalendar import Calendar, Event
 
 class MemoryLike(Protocol):
     def list_facts(
-        self, thread_id: str, tag: str | None = None
+        self,
+        thread_id: str,
+        tag: str | None = None,
+        domain: str | None = None,
     ) -> list[tuple[str, str, str | None, bool, Iterable[str]]]: ...
 
 

--- a/agent/context_manager.py
+++ b/agent/context_manager.py
@@ -1,7 +1,7 @@
 # axon/agent/context_manager.py
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Iterable
 
 from memory.memory_handler import MemoryHandler
 from agent.goal_tracker import GoalTracker
@@ -12,6 +12,7 @@ from config.settings import settings
 class ChatMessage:
     identity: str
     text: str
+
 
 class ContextManager:
     """Manages the current conversational context, including thread and identity."""
@@ -30,7 +31,14 @@ class ContextManager:
         )
         self.chat_history: List[ChatMessage] = []
 
-    def add_fact(self, key: str, value: str, identity: Optional[str] = None) -> None:
+    def add_fact(
+        self,
+        key: str,
+        value: str,
+        identity: Optional[str] = None,
+        domain: Optional[str] = None,
+        tags: Iterable[str] | None = None,
+    ) -> None:
         """
         Adds a fact to memory within the current context.
         """
@@ -39,6 +47,8 @@ class ContextManager:
             key=key,
             value=value,
             identity=identity or self.identity,
+            domain=domain,
+            tags=tags,
         )
 
     def get_fact(self, key: str, include_identity: bool = False):
@@ -61,12 +71,20 @@ class ContextManager:
         print(f"Context thread switched to: {thread_id}")
         self.thread_id = thread_id
 
-    def update_fact(self, key: str, value: str):
+    def update_fact(
+        self,
+        key: str,
+        value: str,
+        domain: Optional[str] = None,
+        tags: Iterable[str] | None = None,
+    ) -> None:
         self.memory_handler.update_fact(
             thread_id=self.thread_id,
             key=key,
             value=value,
             identity=self.identity,
+            domain=domain,
+            tags=tags,
         )
 
     def delete_fact(self, key: str) -> bool:
@@ -83,4 +101,3 @@ class ContextManager:
             self.goal_tracker.detect_and_add_goal(
                 self.thread_id, text, identity=speaker
             )
-

--- a/agent/pasteback_handler.py
+++ b/agent/pasteback_handler.py
@@ -1,14 +1,20 @@
 import time
-from typing import Protocol
+from typing import Protocol, Iterable
 
 
 class MemoryLike(Protocol):
     """Minimal interface needed from MemoryHandler."""
 
     def add_fact(
-        self, thread_id: str, key: str, value: str, identity: str | None = None
-    ) -> None:
-        ...
+        self,
+        thread_id: str,
+        key: str,
+        value: str,
+        identity: str | None = None,
+        domain: str | None = None,
+        tags: Iterable[str] | None = None,
+    ) -> None: ...
+
 
 class PastebackHandler:
     """Store remote model responses in memory."""
@@ -16,7 +22,13 @@ class PastebackHandler:
     def __init__(self, memory_handler: MemoryLike):
         self.memory_handler = memory_handler
 
-    def store(self, thread_id: str, prompt: str, response: str, model: str = "gpt") -> None:
+    def store(
+        self, thread_id: str, prompt: str, response: str, model: str = "gpt"
+    ) -> None:
         ts = int(time.time())
-        self.memory_handler.add_fact(thread_id, f"cloud_prompt_{ts}", prompt, identity=model)
-        self.memory_handler.add_fact(thread_id, f"cloud_response_{ts}", response, identity=model)
+        self.memory_handler.add_fact(
+            thread_id, f"cloud_prompt_{ts}", prompt, identity=model
+        )
+        self.memory_handler.add_fact(
+            thread_id, f"cloud_response_{ts}", response, identity=model
+        )

--- a/agent/plugin_context.py
+++ b/agent/plugin_context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Iterable
 
 from memory.memory_handler import MemoryHandler
 from agent.goal_tracker import GoalTracker
@@ -15,13 +15,22 @@ class PluginContext:
     thread_id: str = "plugin_thread"
     identity: str = "plugin_user"
 
-    def add_fact(self, key: str, value: str, identity: Optional[str] = None) -> None:
+    def add_fact(
+        self,
+        key: str,
+        value: str,
+        identity: Optional[str] = None,
+        domain: Optional[str] = None,
+        tags: Iterable[str] | None = None,
+    ) -> None:
         """Store a fact in Axon's memory."""
         self.memory_handler.add_fact(
             thread_id=self.thread_id,
             key=key,
             value=value,
             identity=identity or self.identity,
+            domain=domain,
+            tags=tags,
         )
 
     def add_goal(self, text: str, identity: Optional[str] = None) -> None:

--- a/agent/reminder.py
+++ b/agent/reminder.py
@@ -1,4 +1,5 @@
 """Simple in-memory reminder scheduler."""
+
 from __future__ import annotations
 
 import threading
@@ -17,18 +18,19 @@ class MemoryLike(Protocol):
         value: str,
         identity: str | None = None,
         tags: Iterable[str] | None = None,
-    ) -> None:
-        ...
+    ) -> None: ...
 
-    def delete_fact(self, thread_id: str, key: str) -> bool:
-        ...
+    def delete_fact(self, thread_id: str, key: str) -> bool: ...
 
-    def list_facts(self, thread_id: str, tag: str | None = None) -> list[tuple[str, str, str | None, bool, list[str]]]:
-        ...
+    def list_facts(
+        self, thread_id: str, tag: str | None = None, domain: str | None = None
+    ) -> list[tuple[str, str, str | None, bool, list[str]]]: ...
 
 
 class ReminderManager:
-    def __init__(self, notifier: Notifier | None = None, memory_handler: MemoryLike | None = None) -> None:
+    def __init__(
+        self, notifier: Notifier | None = None, memory_handler: MemoryLike | None = None
+    ) -> None:
         self.notifier = notifier or Notifier()
         self.memory_handler = memory_handler
         self._timers: list[threading.Timer] = []
@@ -38,13 +40,17 @@ class ReminderManager:
         if self.memory_handler:
             self.memory_handler.delete_fact(thread_id, key)
 
-    def schedule(self, message: str, delay_seconds: int, thread_id: str = "default_thread") -> str:
+    def schedule(
+        self, message: str, delay_seconds: int, thread_id: str = "default_thread"
+    ) -> str:
         ts = int(time.time()) + delay_seconds
         key = f"reminder_{ts}"
         if self.memory_handler:
             data = json.dumps({"message": message, "time": ts})
             self.memory_handler.add_fact(thread_id, key, data, identity="reminder")
-        timer = threading.Timer(delay_seconds, self._trigger, args=(thread_id, key, message))
+        timer = threading.Timer(
+            delay_seconds, self._trigger, args=(thread_id, key, message)
+        )
         timer.daemon = True
         timer.start()
         self._timers.append(timer)
@@ -54,11 +60,19 @@ class ReminderManager:
         if not self.memory_handler:
             return []
         results: list[dict[str, Any]] = []
-        for key, value, _ident, _locked, _tags in self.memory_handler.list_facts(thread_id):
+        for key, value, _ident, _locked, _tags in self.memory_handler.list_facts(
+            thread_id
+        ):
             if key.startswith("reminder_"):
                 try:
                     data = json.loads(value)
-                    results.append({"key": key, "message": data.get("message"), "time": data.get("time")})
+                    results.append(
+                        {
+                            "key": key,
+                            "message": data.get("message"),
+                            "time": data.get("time"),
+                        }
+                    )
                 except Exception:
                     continue
         return results
@@ -67,4 +81,3 @@ class ReminderManager:
         if self.memory_handler:
             return self.memory_handler.delete_fact(thread_id, key)
         return False
-

--- a/backend/main.py
+++ b/backend/main.py
@@ -119,8 +119,10 @@ async def list_models():
 
 
 @app.get("/memory/{thread_id}")
-async def list_memory(thread_id: str, tag: str | None = None):
-    facts = memory_handler.list_facts(thread_id, tag)
+async def list_memory(
+    thread_id: str, tag: str | None = None, domain: str | None = None
+):
+    facts = memory_handler.list_facts(thread_id, tag, domain)
     return {
         "facts": [
             {
@@ -142,9 +144,12 @@ async def add_memory(
     value: str,
     identity: str | None = None,
     tags: str | None = None,
+    domain: str | None = None,
 ):
     tag_list = [t for t in tags.split(",") if t] if tags else None
-    memory_handler.add_fact(thread_id, key, value, identity, tags=tag_list)
+    memory_handler.add_fact(
+        thread_id, key, value, identity, domain=domain, tags=tag_list
+    )
     return {"status": "ok"}
 
 
@@ -155,9 +160,12 @@ async def update_memory(
     value: str,
     identity: str | None = None,
     tags: str | None = None,
+    domain: str | None = None,
 ):
     tag_list = [t for t in tags.split(",") if t] if tags else None
-    memory_handler.update_fact(thread_id, key, value, identity, tags=tag_list)
+    memory_handler.update_fact(
+        thread_id, key, value, identity, domain=domain, tags=tag_list
+    )
     return {"status": "ok"}
 
 

--- a/memory/preload.py
+++ b/memory/preload.py
@@ -7,7 +7,9 @@ import yaml
 from .memory_handler import MemoryHandler
 
 
-def preload(memory_handler: MemoryHandler, path: str = "data/initial_memory.yaml") -> None:
+def preload(
+    memory_handler: MemoryHandler, path: str = "data/initial_memory.yaml"
+) -> None:
     try:
         with open(path, "r") as f:
             data = yaml.safe_load(f)
@@ -21,11 +23,10 @@ def preload(memory_handler: MemoryHandler, path: str = "data/initial_memory.yaml
             key=fact.get("key"),
             value=fact.get("value"),
             identity=fact.get("identity"),
-            tags=[fact.get("domain")] if fact.get("domain") else None,
+            domain=fact.get("domain"),
         )
 
     for i, message in enumerate(data.get("mcp_messages", []), start=1):
         memory_handler.add_fact(
             thread_id="mcp", key=f"mcp_message_{i}", value=json.dumps(message)
         )
-

--- a/tests/test_cli_remember.py
+++ b/tests/test_cli_remember.py
@@ -6,9 +6,12 @@ def test_remember_command(monkeypatch):
     calls = []
 
     class DummyCM:
-        def __init__(self, thread_id="cli_thread", identity="cli_user", goal_tracker=None):
+        def __init__(
+            self, thread_id="cli_thread", identity="cli_user", goal_tracker=None
+        ):
             pass
-        def add_fact(self, key, value):
+
+        def add_fact(self, key, value, identity=None, domain=None, tags=None):
             calls.append((key, value))
 
     monkeypatch.setattr(main, "ContextManager", DummyCM)
@@ -16,4 +19,3 @@ def test_remember_command(monkeypatch):
     result = runner.invoke(main.app, ["remember", "foo", "bar"])
     assert result.exit_code == 0
     assert calls == [("foo", "bar")]
-

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,26 +1,35 @@
 from agent.context_manager import ContextManager, ChatMessage
 
+
 class DummyMemory:
     def __init__(self):
         self.add_calls = []
-    def add_fact(self, thread_id, key, value, identity=None):
+
+    def add_fact(self, thread_id, key, value, identity=None, domain=None, tags=None):
         self.add_calls.append((thread_id, key, value, identity))
+
     def update_fact(self, *a, **k):
         pass
+
     def delete_fact(self, *a, **k):
         return False
+
     def set_lock(self, *a, **k):
         return False
+
 
 class DummyGoalTracker:
     def __init__(self):
         self.detect_calls = []
+
     def detect_and_add_goal(self, thread_id, text, identity=None):
         self.detect_calls.append((thread_id, text, identity))
 
 
 def test_chat_history_records_identity(monkeypatch):
-    monkeypatch.setattr("agent.context_manager.MemoryHandler", lambda db_uri=None: DummyMemory())
+    monkeypatch.setattr(
+        "agent.context_manager.MemoryHandler", lambda db_uri=None: DummyMemory()
+    )
     tracker = DummyGoalTracker()
     cm = ContextManager(thread_id="t1", identity="alice", goal_tracker=tracker)
     cm.add_chat_message("hello")

--- a/tests/test_memory_domain.py
+++ b/tests/test_memory_domain.py
@@ -1,0 +1,56 @@
+from memory.memory_handler import MemoryHandler
+
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.fetchall_result = []
+
+    def execute(self, query, params=None):
+        self.queries.append((str(query).strip(), params))
+
+    def fetchall(self):
+        return self.fetchall_result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyConn:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_add_fact_with_domain(monkeypatch):
+    cur = DummyCursor()
+    conn = DummyConn(cur)
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
+    handler = MemoryHandler(db_uri="postgresql://ignore")
+    handler.add_fact("t1", "k", "v", domain="work")
+    query, params = cur.queries[-1]
+    assert "INSERT INTO facts" in query
+    assert params[-1] == "work"
+
+
+def test_list_facts_domain(monkeypatch):
+    cur = DummyCursor()
+    cur.fetchall_result = []
+    conn = DummyConn(cur)
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
+    handler = MemoryHandler(db_uri="postgresql://ignore")
+    handler.list_facts("t1", domain="work")
+    query, params = cur.queries[-1]
+    assert "domain = %s" in query
+    assert params[-1] == "work"

--- a/tests/test_pasteback_handler.py
+++ b/tests/test_pasteback_handler.py
@@ -2,34 +2,39 @@ from agent.pasteback_handler import PastebackHandler
 from agent.llm_router import LLMRouter
 import json
 
+
 class DummyMemory:
     def __init__(self):
         self.calls = []
-    def add_fact(self, thread_id, key, value, identity=None):
-        self.calls.append((thread_id, key, value, identity))
+
+    def add_fact(self, thread_id, key, value, identity=None, domain=None, tags=None):
+        self.calls.append((thread_id, key, value, identity, domain, tags))
 
 
 def test_store_adds_two_facts():
     mem = DummyMemory()
     handler = PastebackHandler(mem)
-    handler.store('t1', 'prompt text', 'reply text', model='gpt-4o')
+    handler.store("t1", "prompt text", "reply text", model="gpt-4o")
     assert len(mem.calls) == 2
     first_key = mem.calls[0][1]
     second_key = mem.calls[1][1]
-    assert first_key.startswith('cloud_prompt_')
-    assert second_key.startswith('cloud_response_')
-    assert mem.calls[0][0] == 't1'
-    assert mem.calls[0][2] == 'prompt text'
-    assert mem.calls[1][2] == 'reply text'
-    assert mem.calls[0][3] == 'gpt-4o'
-    assert mem.calls[1][3] == 'gpt-4o'
+    assert first_key.startswith("cloud_prompt_")
+    assert second_key.startswith("cloud_response_")
+    assert mem.calls[0][0] == "t1"
+    assert mem.calls[0][2] == "prompt text"
+    assert mem.calls[1][2] == "reply text"
+    assert mem.calls[0][3] == "gpt-4o"
+    assert mem.calls[1][3] == "gpt-4o"
 
 
 def test_full_copy_paste_cycle():
     mem = DummyMemory()
     handler = PastebackHandler(mem)
     router = LLMRouter()
-    prompt_json = json.loads(router.get_response('Please summarize these notes', model='local'))
-    handler.store('t2', prompt_json['prompt'], 'result text', model=prompt_json['model'])
+    prompt_json = json.loads(
+        router.get_response("Please summarize these notes", model="local")
+    )
+    handler.store(
+        "t2", prompt_json["prompt"], "result text", model=prompt_json["model"]
+    )
     assert len(mem.calls) == 2
-

--- a/tests/test_plugin_context.py
+++ b/tests/test_plugin_context.py
@@ -6,7 +6,7 @@ class DummyMemory:
     def __init__(self):
         self.add_calls = []
 
-    def add_fact(self, thread_id, key, value, identity=None):
+    def add_fact(self, thread_id, key, value, identity=None, domain=None, tags=None):
         self.add_calls.append((thread_id, key, value, identity))
 
 
@@ -21,7 +21,9 @@ class DummyGoals:
 def test_context_helpers():
     mem = DummyMemory()
     goals = DummyGoals()
-    ctx = PluginContext(memory_handler=mem, goal_tracker=goals, thread_id="t1", identity="bob")
+    ctx = PluginContext(
+        memory_handler=mem, goal_tracker=goals, thread_id="t1", identity="bob"
+    )
     ctx.add_fact("k", "v")
     ctx.add_goal("do it")
     assert mem.add_calls == [("t1", "k", "v", "bob")]

--- a/tests/test_reminder.py
+++ b/tests/test_reminder.py
@@ -13,7 +13,9 @@ def test_schedule(monkeypatch):
             self.added = []
             self.deleted = []
 
-        def add_fact(self, thread_id, key, value, identity=None, tags=None):
+        def add_fact(
+            self, thread_id, key, value, identity=None, domain=None, tags=None
+        ):
             self.added.append((thread_id, key, value, identity))
 
         def delete_fact(self, thread_id, key):
@@ -21,7 +23,7 @@ def test_schedule(monkeypatch):
             self.added = [item for item in self.added if item[1] != key]
             return True
 
-        def list_facts(self, thread_id, tag=None):
+        def list_facts(self, thread_id, tag=None, domain=None):
             return [(k, v, None, False, []) for _, k, v, _ in self.added]
 
     mem = DummyMem()
@@ -29,8 +31,8 @@ def test_schedule(monkeypatch):
     key = rm.schedule("hi", 0, thread_id="t1")
     # wait briefly for timer
     import time
+
     time.sleep(0.1)
     assert called == [("Reminder", "hi")]
     assert mem.deleted == [("t1", key)]
     assert rm.list_reminders("t1") == []
-


### PR DESCRIPTION
## Summary
- add `domain` column to memory table and support it in add/update/list methods
- expose domain filtering via API
- propagate domain parameter through context and plugin helpers
- update test helpers and add new tests for domain filtering

## Reasoning
The roadmap listed domain scoping as a missing feature. The memory handler only stored domains in tags, so filtering was awkward. Introducing a dedicated `domain` column allows efficient lookups and clearer API semantics. Existing calls still work with optional arguments, and dummy objects in tests now accept the new parameters.

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_688121fcd230832ba959c579edea9328