### PR TITLE
Add mass deletion and plugin reload features

### DIFF
--- a/agent/goal_tracker.py
+++ b/agent/goal_tracker.py
@@ -54,13 +54,22 @@ class GoalTracker:
 
     def _is_deferred(self, text: str) -> bool:
         """Return True if the text sounds like a vague or deferred idea."""
-        vague_patterns = [r"someday i might", r"maybe", r"one day", r"i might", r"perhaps", r"eventually"]
+        vague_patterns = [
+            r"someday i might",
+            r"maybe",
+            r"one day",
+            r"i might",
+            r"perhaps",
+            r"eventually",
+        ]
         for pat in vague_patterns:
             if re.search(pat, text, re.IGNORECASE):
                 return True
         return False
 
-    def add_goal(self, thread_id: str, text: str, identity: Optional[str] = None) -> None:
+    def add_goal(
+        self, thread_id: str, text: str, identity: Optional[str] = None
+    ) -> None:
         if not self.conn:
             return
         deferred = self._is_deferred(text)
@@ -112,3 +121,12 @@ class GoalTracker:
             )
             self.conn.commit()
 
+    def delete_goals(self, thread_id: str) -> int:
+        """Delete all goals for a thread."""
+        if not self.conn:
+            return 0
+        with self.conn.cursor() as cur:
+            cur.execute("DELETE FROM goals WHERE thread_id=%s", (thread_id,))
+            deleted = cur.rowcount
+            self.conn.commit()
+            return deleted

--- a/backend/main.py
+++ b/backend/main.py
@@ -175,6 +175,15 @@ async def delete_memory(thread_id: str, key: str):
     return {"deleted": deleted}
 
 
+@app.delete("/memory/{thread_id}")
+async def delete_memory_bulk(
+    thread_id: str, domain: str | None = None, tag: str | None = None
+):
+    """Delete multiple facts by thread, optionally filtered."""
+    deleted = memory_handler.delete_facts(thread_id, domain=domain, tag=tag)
+    return {"deleted": deleted}
+
+
 @app.post("/memory/{thread_id}/{key}/lock")
 async def lock_memory(thread_id: str, key: str, locked: bool = True):
     changed = memory_handler.set_lock(thread_id, key, locked)
@@ -237,6 +246,13 @@ async def list_deferred(thread_id: str):
             for g_id, text, done, ident, deferred in goals
         ]
     }
+
+
+@app.delete("/goals/{thread_id}")
+async def delete_goals(thread_id: str):
+    """Delete all goals for a thread."""
+    deleted = goal_tracker.delete_goals(thread_id)
+    return {"deleted": deleted}
 
 
 @app.get("/profiles/{identity}")

--- a/main.py
+++ b/main.py
@@ -22,6 +22,16 @@ app = typer.Typer(
     help="The main entry point for the Axon project, supporting different operational modes.",
 )
 
+plugins_app = typer.Typer(help="Plugin management commands")
+app.add_typer(plugins_app, name="plugins")
+
+
+@plugins_app.command("reload")
+def reload_plugins_cmd() -> None:
+    """Reload plugins from disk and display the available set."""
+    load_plugins(hot_reload=True)
+    print(f"Plugins loaded: {list(AVAILABLE_PLUGINS.keys())}")
+
 
 @app.command()
 def web():

--- a/memory/memory_handler.py
+++ b/memory/memory_handler.py
@@ -182,6 +182,26 @@ class MemoryHandler:
             self.conn.commit()
             return deleted
 
+    def delete_facts(
+        self, thread_id: str, domain: Optional[str] = None, tag: Optional[str] = None
+    ) -> int:
+        """Delete multiple facts optionally filtered by domain or tag."""
+        if not self.conn:
+            return 0
+        with self.conn.cursor() as cur:
+            query = "DELETE FROM facts WHERE thread_id=%s AND locked=FALSE"
+            params = [thread_id]
+            if domain:
+                query += " AND domain=%s"
+                params.append(domain)
+            if tag:
+                query += " AND tags ILIKE %s"
+                params.append(f"%{tag}%")
+            cur.execute(query, params)
+            deleted = cur.rowcount
+            self.conn.commit()
+            return deleted
+
     def set_lock(self, thread_id: str, key: str, locked: bool) -> bool:
         if not self.conn:
             return False

--- a/phases/roadmap.md
+++ b/phases/roadmap.md
@@ -50,7 +50,7 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 
 ### Phase 2 Improvements (Planned)
 - [ ] Domain scoping in memory tables and API
-- [ ] Mass deletion endpoints and CLI plugin reload
+- [x] Mass deletion endpoints and CLI plugin reload
 - [ ] Permission scoping for plugins
 - [ ] Goal priority and deadline fields
 - [ ] Periodic prompts for deferred goals

--- a/tests/test_cli_reload_plugins.py
+++ b/tests/test_cli_reload_plugins.py
@@ -1,0 +1,15 @@
+from typer.testing import CliRunner
+import main
+
+
+def test_reload_plugins(monkeypatch):
+    calls = []
+
+    def dummy_load(hot_reload=False):
+        calls.append(hot_reload)
+
+    monkeypatch.setattr(main, "load_plugins", dummy_load)
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["plugins", "reload"])
+    assert result.exit_code == 0
+    assert calls == [True]

--- a/tests/test_mass_delete_api.py
+++ b/tests/test_mass_delete_api.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from backend.main import app, memory_handler, goal_tracker
+
+
+def test_delete_memory_bulk(monkeypatch):
+    monkeypatch.setattr(memory_handler, "delete_facts", lambda *a, **k: 5)
+    client = TestClient(app)
+    resp = client.delete("/memory/t1")
+    assert resp.status_code == 200
+    assert resp.json() == {"deleted": 5}
+
+
+def test_delete_goals(monkeypatch):
+    monkeypatch.setattr(goal_tracker, "delete_goals", lambda *a, **k: 2)
+    client = TestClient(app)
+    resp = client.delete("/goals/t1")
+    assert resp.status_code == 200
+    assert resp.json() == {"deleted": 2}

--- a/tests/test_memory_domain.py
+++ b/tests/test_memory_domain.py
@@ -5,6 +5,7 @@ class DummyCursor:
     def __init__(self):
         self.queries = []
         self.fetchall_result = []
+        self.rowcount = 0
 
     def execute(self, query, params=None):
         self.queries.append((str(query).strip(), params))
@@ -53,4 +54,16 @@ def test_list_facts_domain(monkeypatch):
     handler.list_facts("t1", domain="work")
     query, params = cur.queries[-1]
     assert "domain = %s" in query
+    assert params[-1] == "work"
+
+
+def test_delete_facts_domain(monkeypatch):
+    cur = DummyCursor()
+    conn = DummyConn(cur)
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
+    handler = MemoryHandler(db_uri="postgresql://ignore")
+    handler.delete_facts("t1", domain="work")
+    query, params = cur.queries[-1]
+    assert "DELETE FROM facts" in query
+    assert "domain=%s" in query
     assert params[-1] == "work"


### PR DESCRIPTION
## Summary
- add MemoryHandler.delete_facts for bulk deletion
- add GoalTracker.delete_goals for clearing goals
- expose `/memory/{thread_id}` and `/goals/{thread_id}` delete endpoints
- support `axon plugins reload` to hot-reload plugins
- check off roadmap item and test new behaviour

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_6881254fc0c8832b95696cbcca3c619d