### PR TITLE
Add ResponseShaper for persona tone

### DIFF
--- a/agent/llm_router.py
+++ b/agent/llm_router.py
@@ -9,6 +9,7 @@ from qwen_agent.tools import TOOL_REGISTRY
 from config.settings import settings
 
 from .fallback_prompt import generate_prompt, to_json
+from .response_shaper import ResponseShaper
 
 
 class LLMRouter:
@@ -76,7 +77,8 @@ class LLMRouter:
             output = assistant.run_nonstream(messages)
             text = self._extract_text(output)
             if text:
-                return text
+                shaper = ResponseShaper()
+                return shaper.shape(text, persona=persona, tone=tone)
             return "Sorry, I received an empty response from Qwen3.".strip()
         except Exception:
             fallback = generate_prompt(

--- a/agent/response_shaper.py
+++ b/agent/response_shaper.py
@@ -1,0 +1,67 @@
+"""Utilities for tweaking LLM responses based on persona and tone."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+class ResponseShaper:
+    """Apply simple stylistic transformations to model output."""
+
+    _INFORMAL = {
+        r"\bI am\b": "I'm",
+        r"\byou are\b": "you're",
+        r"\bdo not\b": "don't",
+        r"\bdoes not\b": "doesn't",
+        r"\bcan not\b": "can't",
+        r"\bcannot\b": "can't",
+        r"\bwill not\b": "won't",
+        r"\bare not\b": "aren't",
+        r"\bis not\b": "isn't",
+        r"\bit is\b": "it's",
+    }
+
+    _FORMAL = {
+        r"\bI'm\b": "I am",
+        r"\byou're\b": "you are",
+        r"\bdon't\b": "do not",
+        r"\bdoesn't\b": "does not",
+        r"\bcan't\b": "cannot",
+        r"\bwon't\b": "will not",
+        r"\baren't\b": "are not",
+        r"\bisn't\b": "is not",
+        r"\bit's\b": "it is",
+    }
+
+    _PERSONA_PREFIX = {
+        "partner": "Hey there,",
+    }
+
+    def __init__(self, max_length: Optional[int] = None) -> None:
+        self.max_length = max_length
+
+    def _apply_map(self, text: str, mapping: dict[str, str]) -> str:
+        for pat, repl in mapping.items():
+            text = re.sub(pat, repl, text, flags=re.IGNORECASE)
+        return text
+
+    def shape(
+        self, text: str, persona: str | None = None, tone: str | None = None
+    ) -> str:
+        """Return the text adjusted for persona and tone."""
+        shaped = text
+
+        if tone == "informal":
+            shaped = self._apply_map(shaped, self._INFORMAL)
+        elif tone == "formal":
+            shaped = self._apply_map(shaped, self._FORMAL)
+
+        prefix = self._PERSONA_PREFIX.get(persona or "", "")
+        if prefix:
+            shaped = f"{prefix} {shaped}".strip()
+
+        if self.max_length is not None and len(shaped) > self.max_length:
+            shaped = shaped[: self.max_length].rstrip()
+
+        return shaped

--- a/tests/test_response_shaper.py
+++ b/tests/test_response_shaper.py
@@ -1,0 +1,33 @@
+from agent.response_shaper import ResponseShaper
+import agent.llm_router as llm_router
+from agent.llm_router import LLMRouter
+
+
+class DummyAssistant:
+    def __init__(self, function_list, llm, generate_cfg=None):
+        pass
+
+    def run_nonstream(self, messages):
+        return [{"role": "assistant", "content": "I am ready to help you."}]
+
+
+def test_informal_contractions():
+    shaper = ResponseShaper()
+    result = shaper.shape("I am fine and you are great", tone="informal")
+    assert "I'm" in result
+    assert "you're" in result
+
+
+def test_router_profile_styles(monkeypatch):
+    monkeypatch.setattr(llm_router, "Assistant", DummyAssistant)
+    monkeypatch.setattr(llm_router, "TOOL_REGISTRY", {})
+    router = LLMRouter()
+    neutral = router.get_response(
+        "hi", model="local", persona="assistant", tone="neutral"
+    )
+    informal = router.get_response(
+        "hi", model="local", persona="partner", tone="informal"
+    )
+    assert neutral != informal
+    assert informal.startswith("Hey there,")
+    assert "I'm" in informal


### PR DESCRIPTION
## Summary
- implement `ResponseShaper` to adapt style using persona/tone
- apply shaping in `LLMRouter.get_response`
- test informal contractions and persona style differences

## Reasoning
Adds Phase 5.2 capability for identity-adaptive voice. `ResponseShaper` modifies LLM replies with simple tone-aware rules and length limits. `LLMRouter` now pipes model output through this utility so responses honour user profile preferences. Tests verify contractions are applied and profile settings produce different text.


------
https://chatgpt.com/codex/tasks/task_e_688143c15260832ba57587c9edec58a6