### PR TITLE
Enable identity-filtered vector search

### DIFF
--- a/memory/vector_store.py
+++ b/memory/vector_store.py
@@ -24,7 +24,13 @@ class VectorStore:
             print(f"Error connecting to Qdrant: {e}")
             self.client = None
 
-    def add_memory(self, collection_name: str, text_content: str, vector: list[float]):
+    def add_memory(
+        self,
+        collection_name: str,
+        text_content: str,
+        vector: list[float],
+        identity: str | None = None,
+    ) -> None:
         """
         Adds a new memory (text and its vector representation) to a Qdrant collection.
         """
@@ -37,10 +43,21 @@ class VectorStore:
         self.client.recreate_collection(
             collection_name=collection_name,
             vectors_config=models.VectorParams(
-                size=len(vector), distance=models.Distance.COSINE
+                size=len(vector),
+                distance=models.Distance.COSINE,
             ),
-            on_disk_payload=True,  # Recommended for performance
+            on_disk_payload=True,
         )
+
+        # Ensure there is an index on the identity payload field for filtering
+        try:
+            self.client.create_payload_index(
+                collection_name,
+                field_name="identity",
+                field_schema=models.PayloadSchemaType.KEYWORD,
+            )
+        except Exception:
+            pass
 
         # Use a unique ID for each memory point
         point_id = str(uuid.uuid4())
@@ -49,7 +66,9 @@ class VectorStore:
             collection_name=collection_name,
             points=[
                 models.PointStruct(
-                    id=point_id, vector=vector, payload={"text": text_content}
+                    id=point_id,
+                    vector=vector,
+                    payload={"text": text_content, "identity": identity},
                 )
             ],
             wait=True,
@@ -57,13 +76,43 @@ class VectorStore:
         print(f"Added memory to collection '{collection_name}'")
 
     def search_memory(
-        self, collection_name: str, query_vector: list[float], limit: int = 5
-    ):
+        self,
+        collection_name: str,
+        query_vector: list[float],
+        limit: int = 5,
+        identity: str | None = None,
+    ) -> list[models.ScoredPoint]:
         """
         Searches for similar memories in a Qdrant collection using a query vector.
         """
         if not self.client:
             print("No Qdrant client connection.")
+            return []
+
+        query_filter = None
+        if identity:
+            query_filter = models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="identity",
+                        match=models.MatchValue(value=identity),
+                    )
+                ]
+            )
+
+        try:
+            search_result = self.client.search(
+                collection_name=collection_name,
+                query_vector=query_vector,
+                limit=limit,
+                query_filter=query_filter,
+            )
+            print(
+                f"Searched collection '{collection_name}' and found {len(search_result)} results."
+            )
+            return search_result
+        except Exception as e:
+            print(f"Could not search collection '{collection_name}': {e}")
             return []
 
     def hybrid_search(
@@ -72,23 +121,16 @@ class VectorStore:
         query_vector: list[float],
         llm_confidence: float,
         limit: int = 5,
+        identity: str | None = None,
     ) -> list[models.ScoredPoint]:
         """Return search results weighted by an LLM confidence score."""
-        results = self.search_memory(collection_name, query_vector, limit)
+        results = self.search_memory(
+            collection_name,
+            query_vector,
+            limit=limit,
+            identity=identity,
+        )
         for r in results:
             if hasattr(r, "score"):
                 r.score = 0.5 * r.score + 0.5 * llm_confidence
         return results
-
-        try:
-            search_result = self.client.search(
-                collection_name=collection_name, query_vector=query_vector, limit=limit
-            )
-            print(
-                f"Searched collection '{collection_name}' and found {len(search_result)} results."
-            )
-            return search_result
-        except Exception as e:
-            # This can happen if the collection doesn't exist yet.
-            print(f"Could not search collection '{collection_name}': {e}")
-            return []

--- a/tests/test_vector_store_identity.py
+++ b/tests/test_vector_store_identity.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from memory.vector_store import VectorStore
+from qdrant_client.http import models
+
+
+class DummyQdrantClient:
+    def __init__(self):
+        self.collections = {}
+        self.indices = []
+
+    def recreate_collection(
+        self, collection_name, vectors_config, on_disk_payload=True
+    ):
+        self.collections.setdefault(collection_name, [])
+
+    def create_payload_index(
+        self,
+        collection_name,
+        field_name,
+        field_schema=models.PayloadSchemaType.KEYWORD,
+        **kwargs,
+    ):
+        self.indices.append((collection_name, field_name))
+
+    def upsert(self, collection_name, points, wait=True):
+        self.collections.setdefault(collection_name, []).extend(points)
+
+    def search(
+        self, collection_name, query_vector, limit=5, query_filter=None, **kwargs
+    ):
+        points = self.collections.get(collection_name, [])
+        results = []
+        for p in points:
+            if query_filter and query_filter.must:
+                cond = query_filter.must[0]
+                if p.payload.get(cond.key) != cond.match.value:
+                    continue
+            results.append(SimpleNamespace(id=p.id, payload=p.payload, score=1.0))
+        return results[:limit]
+
+
+def make_store(dummy):
+    store = VectorStore(host="ignore", port=0)
+    store.client = dummy
+    return store
+
+
+def test_search_filters_by_identity():
+    dummy = DummyQdrantClient()
+    store = make_store(dummy)
+    store.add_memory("col", "a1", [0.1], identity="alice")
+    store.add_memory("col", "b1", [0.1], identity="bob")
+
+    alice = store.search_memory("col", [0.1], identity="alice")
+    bob = store.search_memory("col", [0.1], identity="bob")
+    assert len(alice) == 1
+    assert alice[0].payload["identity"] == "alice"
+    assert len(bob) == 1
+    assert bob[0].payload["identity"] == "bob"
+
+
+def test_hybrid_search_scores_adjusted():
+    dummy = DummyQdrantClient()
+    store = make_store(dummy)
+    store.add_memory("col", "a1", [0.1], identity="alice")
+    results = store.hybrid_search("col", [0.1], llm_confidence=0.8, identity="alice")
+    assert results[0].payload["identity"] == "alice"
+    assert results[0].score == 0.5 * 1.0 + 0.5 * 0.8


### PR DESCRIPTION
## Summary
- add identity field support to Qdrant VectorStore
- allow searching and hybrid search scoped to a specific identity
- test vector store identity filtering

## Reasoning
Phase 5.3 calls for weighting memories by identity. Adding the identity to each payload and indexing the field lets Qdrant filter by the current speaker. The search methods now accept an `identity` argument so calling code can limit results to the active user. Tests verify that two identities return distinct memories and that scores are adjusted during hybrid search.

## Testing
- `make verify`


------
https://chatgpt.com/codex/tasks/task_e_6881478ae8c0832bb614cdeb5b8242a1