### PR TITLE
Implement habit recognition engine

### DIFF
--- a/agent/habit_tracker.py
+++ b/agent/habit_tracker.py
@@ -1,0 +1,89 @@
+# axon/agent/habit_tracker.py
+"""Recognize recurring goals as habits."""
+
+from __future__ import annotations
+
+import re
+import threading
+
+from .goal_tracker import GoalTracker
+from memory.memory_handler import MemoryHandler
+from .notifier import Notifier
+
+
+class HabitTracker:
+    """Analyze goal history to detect routine habits."""
+
+    def __init__(
+        self,
+        goal_tracker: GoalTracker,
+        memory_handler: MemoryHandler,
+        notifier: Notifier | None = None,
+    ) -> None:
+        self.goal_tracker = goal_tracker
+        self.memory_handler = memory_handler
+        self.notifier = notifier or Notifier()
+        self._timer: threading.Timer | None = None
+
+    @staticmethod
+    def _slug(text: str) -> str:
+        return re.sub(r"\W+", "_", text.strip().lower())
+
+    def _find_habits(self, thread_id: str) -> list[tuple[str, str]]:
+        """Return pairs of (weekday, normalized text) that repeat."""
+        goals = self.goal_tracker.list_goals(thread_id)
+        counts: dict[tuple[str, str], int] = {}
+        for _gid, text, _done, _ident, _deferred, _prio, deadline in goals:
+            if deadline is None:
+                continue
+            weekday = deadline.strftime("%A")
+            norm = text.strip().lower()
+            counts[(weekday, norm)] = counts.get((weekday, norm), 0) + 1
+        habits = []
+        for (weekday, norm), count in counts.items():
+            if count >= 2:
+                habits.append((weekday, norm))
+        return habits
+
+    def update_habits(self, thread_id: str) -> None:
+        """Analyze goals and store detected habits in memory."""
+        for weekday, norm in self._find_habits(thread_id):
+            key = f"habit_{weekday}_{self._slug(norm)}"
+            value = f"{norm} on {weekday}"
+            self.memory_handler.add_fact(
+                thread_id,
+                key,
+                value,
+                tags=["routine"],
+            )
+
+    def summarize_habits(self, thread_id: str) -> str:
+        entries = self.memory_handler.list_facts(thread_id, tag="routine")
+        summaries: list[str] = []
+        for _key, value, _ident, _locked, _tags in entries:
+            summaries.append(value)
+        return "; ".join(summaries)
+
+    def _notify_summary(self, thread_id: str, interval: float) -> None:
+        self.update_habits(thread_id)
+        summary = self.summarize_habits(thread_id)
+        if summary:
+            self.notifier.notify("Habit summary", summary)
+        self.start_summary(thread_id, interval)
+
+    def start_summary(self, thread_id: str, interval_seconds: float = 86400) -> None:
+        """Begin periodic habit summaries."""
+        if self._timer:
+            self._timer.cancel()
+        self._timer = threading.Timer(
+            interval_seconds,
+            self._notify_summary,
+            args=(thread_id, interval_seconds),
+        )
+        self._timer.daemon = True
+        self._timer.start()
+
+    def stop_summary(self) -> None:
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None

--- a/tests/test_habit_tracker.py
+++ b/tests/test_habit_tracker.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+from agent.habit_tracker import HabitTracker
+
+
+class DummyGoals:
+    def list_goals(self, thread_id):
+        return [
+            (1, "Fast", False, "bob", False, 0, datetime(2024, 8, 5)),
+            (2, "Fast", False, "bob", False, 0, datetime(2024, 8, 12)),
+            (3, "Fast", False, "bob", False, 0, datetime(2024, 8, 13)),
+        ]
+
+
+class DummyMemory:
+    def __init__(self):
+        self.added = []
+
+    def add_fact(self, thread_id, key, value, identity=None, domain=None, tags=None):
+        self.added.append((thread_id, key, value, tags or []))
+
+    def list_facts(self, thread_id, tag=None, domain=None):
+        results = []
+        for t, key, value, tags in self.added:
+            if t != thread_id:
+                continue
+            if tag and tag not in tags:
+                continue
+            results.append((key, value, None, False, tags))
+        return results
+
+
+class DummyNotifier:
+    def __init__(self):
+        self.calls = []
+
+    def notify(self, title, message):
+        self.calls.append((title, message))
+
+
+def test_update_habits_records_fact():
+    mem = DummyMemory()
+    tracker = HabitTracker(DummyGoals(), mem, notifier=DummyNotifier())
+    tracker.update_habits("t1")
+    assert ("t1", "habit_Monday_fast", "fast on Monday", ["routine"]) in mem.added
+
+
+def test_notify_summary(monkeypatch):
+    mem = DummyMemory()
+    notifier = DummyNotifier()
+    tracker = HabitTracker(DummyGoals(), mem, notifier=notifier)
+    monkeypatch.setattr(tracker, "start_summary", lambda *a, **k: None)
+    tracker._notify_summary("t1", 0)
+    assert notifier.calls
+    assert "fast on Monday" in notifier.calls[0][1]


### PR DESCRIPTION
## Summary
- add HabitTracker to analyze GoalTracker patterns and store habits in memory
- include new tests for habit detection and notifications

## Reasoning
Phase 5.4 calls for a habit recognition engine to detect recurring goals. The new `HabitTracker` scans goal history for repeated tasks on the same weekday and records them as facts tagged `routine`. A scheduled summary surfaces these habits through the notifier.

## Testing
- `make lint`
- `make type`
- `make install`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68814b9b0048832bb1cd74cf1502cb22