### PR TITLE
Implement platform-aware notifier

### DIFF
--- a/agent/notifier.py
+++ b/agent/notifier.py
@@ -1,19 +1,85 @@
-"""Simple notification helper using plyer if available."""
+"""Cross-platform system notifications with optional TTS fallback."""
+
 from __future__ import annotations
 
+import platform
+import shutil
+import subprocess
+
 try:
-    from plyer import notification
+    from plyer import notification  # pragma: no cover - optional dep
 except Exception:  # pragma: no cover - optional dep
     notification = None
 
 
 class Notifier:
+    """Send desktop notifications and optionally speak them."""
+
+    def __init__(self) -> None:
+        self.platform = platform.system().lower()
+        self.tts_cmd = self._detect_tts()
+
+    def _detect_tts(self) -> list[str] | None:
+        if shutil.which("piper"):
+            return ["piper", "--text"]
+        if self.platform == "darwin" and shutil.which("say"):
+            return ["say"]
+        if self.platform.startswith("linux") and shutil.which("espeak"):
+            return ["espeak"]
+        if self.platform.startswith("win") and shutil.which("powershell"):
+            return ["powershell", "-Command"]
+        return None
+
+    def _speak(self, text: str) -> None:
+        if not self.tts_cmd:
+            return
+        try:
+            if self.tts_cmd[0] == "powershell":
+                subprocess.run(
+                    self.tts_cmd
+                    + [
+                        "Add-Type -AssemblyName System.Speech; (New-Object System.Speech.Synthesis.SpeechSynthesizer).Speak('{}')".format(
+                            text.replace("'", " ")
+                        )
+                    ],
+                    check=True,
+                )
+            else:
+                subprocess.run(self.tts_cmd + [text], check=True)
+        except Exception:  # pragma: no cover - best effort
+            pass
+
     def notify(self, title: str, message: str) -> None:
-        if notification:
+        text = f"{title}: {message}"
+        sent = False
+        if self.platform.startswith("linux") and shutil.which("notify-send"):
+            try:
+                subprocess.run(["notify-send", title, message], check=True)
+                sent = True
+            except Exception:  # pragma: no cover - optional
+                sent = False
+        elif self.platform == "darwin":
+            try:
+                subprocess.run(
+                    [
+                        "osascript",
+                        "-e",
+                        f'display notification "{message}" with title "{title}"',
+                    ],
+                    check=True,
+                )
+                sent = True
+            except Exception:  # pragma: no cover - optional
+                sent = False
+
+        if not sent and notification:
             try:
                 notification.notify(title=title, message=message)
-            except Exception:
-                print(f"[NOTIFY] {title}: {message}")
-        else:  # fallback to console output
-            print(f"[NOTIFY] {title}: {message}")
+                sent = True
+            except Exception:  # pragma: no cover - optional
+                sent = False
 
+        if not sent:
+            print(f"[NOTIFY] {text}")
+
+        self._speak(text)


### PR DESCRIPTION
## Summary
- implement cross-platform notification logic
- add text-to-speech fallback options

## Reasoning
- The roadmap for Desktop/System Notifications (phase 5.6) calls for platform checks and a TTS fallback
- Current notifier only uses plyer and doesn't try native tools or TTS

## Testing
- `poetry run ruff check agent/notifier.py`
- `poetry run mypy . --show-error-codes`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881503f4120832ba8bdd7682d9ac77b