### PR TITLE
Add PWA wrapper

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,11 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/serviceWorker.js').catch((err) => console.error('SW registration failed', err))
+        })
+      }
+    </script>
   </body>
 </html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Axon",
+  "short_name": "Axon",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vite-plugin-pwa": "^1.0.1"
   }
 }

--- a/frontend/serviceWorker.ts
+++ b/frontend/serviceWorker.ts
@@ -1,0 +1,35 @@
+// frontend/serviceWorker.ts
+const CACHE_NAME = 'axon-cache-v1';
+const OFFLINE_URLS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/vite.svg',
+];
+
+self.addEventListener('install', (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(OFFLINE_URLS))
+      .then(() => (self as ServiceWorkerGlobalScope).skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : Promise.resolve())))
+      )
+      .then(() => (self as ServiceWorkerGlobalScope).clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event: FetchEvent) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
   const [pasteValue, setPasteValue] = useState('');
   const [selectedModel, setSelectedModel] = useState('qwen3:8b');
   const ws = useRef<WebSocket | null>(null);
-  const sendMcp = (tool: string, args: any) => {
+  const sendMcp = (tool: string, args: Record<string, unknown>) => {
     if (ws.current?.readyState !== WebSocket.OPEN) return;
     const msg = {
       mcp_protocol_version: '1.0',
@@ -61,7 +61,7 @@ function App() {
           setMessages(prev => [...prev, agentResponse]);
           return;
         }
-      } catch (_) {
+      } catch {
         // not JSON
       }
       const agentResponse: Message = { sender: 'agent', text: event.data };

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -23,5 +23,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "serviceWorker.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
+import manifest from './manifest.json' assert { type: 'json' }
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      strategies: 'injectManifest',
+      srcDir: '.',
+      filename: 'serviceWorker.ts',
+      manifest,
+    }),
+  ],
 })


### PR DESCRIPTION
## Summary
- add a basic Web App Manifest
- implement a simple service worker for offline caching
- register the worker via Vite and expose manifest in HTML

## Reasoning
Phase 5.8 requires a Progressive Web App wrapper so Axon's chat UI can be installed on mobile devices and works offline. The manifest enables installation and `vite-plugin-pwa` compiles the custom service worker which caches essential assets.

## Testing
- `make verify`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68817692fcbc832b8d028d44b4a83b49