### PR TITLE
Implement session tokens for mobile sync

### DIFF
--- a/agent/session_tracker.py
+++ b/agent/session_tracker.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import secrets
+from typing import Dict, Optional, Tuple
+
+
+class SessionTracker:
+    """In-memory mapping of session tokens to identity and thread."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, Tuple[str, str]] = {}
+
+    def create_session(
+        self, identity: str, thread_id: str | None = None
+    ) -> tuple[str, str]:
+        """Create a new session token for an identity."""
+        token = secrets.token_urlsafe(16)
+        tid = thread_id or f"{identity}_{secrets.token_hex(4)}"
+        self._sessions[token] = (identity, tid)
+        return token, tid
+
+    def resolve(self, token: str) -> Optional[Tuple[str, str]]:
+        """Return the identity and thread for a token if it exists."""
+        return self._sessions.get(token)
+
+    def remove(self, token: str) -> None:
+        """Delete a session token."""
+        self._sessions.pop(token, None)

--- a/poetry.lock
+++ b/poetry.lock
@@ -5579,6 +5579,18 @@ files = [
 ]
 
 [[package]]
+name = "pypng"
+version = "0.20220715.0"
+description = "Pure Python library for saving and loading PNG images"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c"},
+    {file = "pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
@@ -5754,6 +5766,30 @@ urllib3 = ">=1.26.14,<3"
 [package.extras]
 fastembed = ["fastembed (>=0.7,<0.8)"]
 fastembed-gpu = ["fastembed-gpu (>=0.7,<0.8)"]
+
+[[package]]
+name = "qrcode"
+version = "7.4.2"
+description = "QR Code image generator"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "qrcode-7.4.2-py3-none-any.whl", hash = "sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a"},
+    {file = "qrcode-7.4.2.tar.gz", hash = "sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+pypng = "*"
+typing-extensions = "*"
+
+[package.extras]
+all = ["pillow (>=9.1.0)", "pytest", "pytest-cov", "tox", "zest.releaser[recommended]"]
+dev = ["pytest", "pytest-cov", "tox"]
+maintainer = ["zest.releaser[recommended]"]
+pil = ["pillow (>=9.1.0)"]
+test = ["coverage", "pytest"]
 
 [[package]]
 name = "qwen-agent"
@@ -6780,4 +6816,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "f30b99ef8be5fb76cd6497de95612f87d3c0fa6ed7424c59d11b8984e192401e"
+content-hash = "9666a78b4a0bb8faeff5fd04955e1a407d3e60c3f57e24b148195060956de73e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ qwen-agent = "0.0.27"
 python-dateutil = "^2.9.0.post0"
 icalendar = "^6.3.1"
 rich = "^14.0.0"
+qrcode = "^7.4"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.2"

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+from backend.main import app, memory_handler, session_tracker
+
+
+class DummyMem:
+    def list_facts(self, thread_id, tag=None, domain=None):
+        return [("k", "v", "alice", False, [])]
+
+
+def test_login_and_memory(monkeypatch):
+    monkeypatch.setattr(memory_handler, "list_facts", DummyMem().list_facts)
+    # reset sessions for isolated test
+    session_tracker._sessions.clear()
+    client = TestClient(app)
+    resp = client.post("/sessions/login", params={"identity": "alice"})
+    assert resp.status_code == 200
+    data = resp.json()
+    token = data["token"]
+    thread_id = data["thread_id"]
+    resp = client.get(f"/sessions/{token}/memory")
+    assert resp.status_code == 200
+    m = resp.json()
+    assert m["identity"] == "alice"
+    assert m["thread_id"] == thread_id
+    assert m["facts"][0]["key"] == "k"

--- a/tests/test_session_tracker.py
+++ b/tests/test_session_tracker.py
@@ -1,0 +1,9 @@
+from agent.session_tracker import SessionTracker
+
+
+def test_create_and_resolve():
+    st = SessionTracker()
+    token, thread = st.create_session("alice")
+    ident, tid = st.resolve(token)
+    assert ident == "alice"
+    assert tid == thread


### PR DESCRIPTION
## Summary
- add `SessionTracker` to manage per-device sessions
- expose `/sessions/login`, `/sessions/qr/{token}`, and `/sessions/{token}/memory` endpoints
- issue session tokens on WebSocket connect for multi-device sync
- include qrcode dependency
- test new tracker and endpoints

## Testing
- `make verify`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68818a41b08c832bbefe75eae3eff253