### PR TITLE
Improve docs and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ Run `python main.py cli` to load plugins (hot reloaded each launch). Each
 plugin provides metadata such as name, description, and usage via the
 `@plugin` decorator.
 
+## CLI commands
+
+Axon exposes several helper commands via `python main.py`:
+
+```bash
+# list available plugins
+python main.py plugins reload
+
+# start a simple text UI
+python main.py tui
+
+# schedule a reminder in 30 seconds
+python main.py remind "take a break" --delay 30
+
+# import profile defaults from a YAML file
+python main.py import-profiles config/user_prefs.yaml
+
+# set or update an individual profile
+python main.py set-profile jon --persona partner --tone informal
+
+# hands‑free voice shell (if optional deps are installed)
+python main.py voice-shell
+```
+
 To store a fact without using the UI, you can run:
 
 ```bash
@@ -68,8 +92,11 @@ Install them via `pip install pyperclip keyboard` if missing.
 - [docs/plugins.md](docs/plugins.md) explains how to create new plugins.
 - [docs/mcp_setup.md](docs/mcp_setup.md) covers running the MCP helper services.
 - [docs/models.md](docs/models.md) shows how to change the default model.
+- [docs/api.md](docs/api.md) lists the REST endpoints.
 
-Example local configuration files are available in `.env.example` and `config/settings.example.yaml`.
+Example configuration files are available in `.env.example`,
+`config/settings.example.yaml`, and the default profiles in
+`config/user_prefs.yaml`.
 
 ## Qwen-Agent
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,29 @@
+# Backend API Endpoints
+
+Axon's backend exposes a small REST API plus a WebSocket for chat. The table below lists the main endpoints and their purpose.
+
+| Method & Path | Description |
+| --- | --- |
+| `GET /` | Health check for the backend. |
+| `GET /mcp/tools` | List available MCP helper tools and whether they are reachable. |
+| `GET /models` | Return the available local model names. |
+| `POST /sessions/login` | Create a session token for the given identity. Optional `thread_id` may be supplied. |
+| `GET /sessions/qr/{token}` | Return a QR code PNG for a session token. |
+| `GET /sessions/{token}/memory` | List memory facts for the session. Optional `tag` and `domain` filters. |
+| `GET /memory/{thread_id}` | List memory facts by thread. Optional `tag` and `domain` filters. |
+| `POST /memory/{thread_id}` | Add a memory fact. Fields: `key`, `value`, optional `identity`, `tags`, `domain`. |
+| `PUT /memory/{thread_id}` | Update a memory fact. Same parameters as POST. |
+| `DELETE /memory/{thread_id}/{key}` | Delete a specific fact. |
+| `DELETE /memory/{thread_id}` | Delete multiple facts with optional `domain` or `tag` filters. |
+| `POST /memory/{thread_id}/{key}/lock` | Lock or unlock a fact. |
+| `POST /reminders/{thread_id}` | Schedule a reminder message. `delay` in seconds. |
+| `GET /reminders/{thread_id}` | List scheduled reminders. |
+| `DELETE /reminders/{thread_id}/{key}` | Cancel a reminder. |
+| `POST /goals/{thread_id}` | Add a goal/task. |
+| `GET /goals/{thread_id}` | List goals for a thread. |
+| `GET /goals/{thread_id}/deferred` | List deferred or overdue goals. |
+| `DELETE /goals/{thread_id}` | Delete all goals for a thread. |
+| `GET /profiles/{identity}` | Retrieve profile settings for an identity. |
+| `POST /profiles/{identity}` | Update profile settings (`persona`, `tone`, optional `email`). |
+| `WS /ws/chat` | WebSocket endpoint used by the frontend chat client. |
+

--- a/phases/roadmap.md
+++ b/phases/roadmap.md
@@ -101,12 +101,12 @@ This roadmap outlines the development path for **Axon**, a modular, local-first 
 ## 🚀 Phase 5: Personalization & Pro Mode
 **Goal:** Multi-user and adaptive interaction support
 
-- [ ] Identity tracking across sessions (you vs. family vs. guest)
-- [ ] Model persona shaping based on context (assistant/partner/researcher)
-- [ ] Voice adaptation (tone, formality, role-specific)
-- [ ] Calendar and scheduling integration
-- [ ] Notification system for reminders
-- [ ] Mobile UI or TUI wrapper (optional)
+- [x] Identity tracking across sessions (you vs. family vs. guest)
+- [x] Model persona shaping based on context (assistant/partner/researcher)
+- [x] Voice adaptation (tone, formality, role-specific)
+- [x] Calendar and scheduling integration
+- [x] Notification system for reminders
+- [x] Mobile UI or TUI wrapper (optional)
 
 ---
 

--- a/tests/test_habit_tracker.py
+++ b/tests/test_habit_tracker.py
@@ -53,3 +53,11 @@ def test_notify_summary(monkeypatch):
     tracker._notify_summary("t1", 0)
     assert notifier.calls
     assert "fast on Monday" in notifier.calls[0][1]
+
+
+def test_summarize_habits():
+    mem = DummyMemory()
+    tracker = HabitTracker(DummyGoals(), mem, notifier=DummyNotifier())
+    tracker.update_habits("t1")
+    summary = tracker.summarize_habits("t1")
+    assert "fast on Monday" in summary

--- a/tests/test_response_shaper.py
+++ b/tests/test_response_shaper.py
@@ -18,6 +18,19 @@ def test_informal_contractions():
     assert "you're" in result
 
 
+def test_formal_expansions():
+    shaper = ResponseShaper()
+    result = shaper.shape("I'm happy you're here", tone="formal")
+    assert "I am" in result
+    assert "you are" in result
+
+
+def test_max_length_truncates():
+    shaper = ResponseShaper(max_length=5)
+    result = shaper.shape("hello world")
+    assert result == "hello"
+
+
 def test_router_profile_styles(monkeypatch):
     monkeypatch.setattr(llm_router, "Assistant", DummyAssistant)
     monkeypatch.setattr(llm_router, "TOOL_REGISTRY", {})


### PR DESCRIPTION
## Summary
- document CLI commands and configuration files
- add REST API reference
- test additional response shaper and habit tracker behaviour
- mark Phase 5 roadmap tasks complete

## Reasoning
Documentation now covers every command, configuration file and backend endpoint. New tests validate `ResponseShaper` tone options and habit summaries. Phase 5 goals were implemented across the repo so the roadmap is updated accordingly.

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_68818cfc7e8c832b8b8d15ddfbcb602e