### PR TITLE
Fix Qdrant collection re-creation

### DIFF
--- a/memory/vector_store.py
+++ b/memory/vector_store.py
@@ -38,16 +38,18 @@ class VectorStore:
             print("No Qdrant client connection.")
             return
 
-        # Ensure the collection exists before adding data.
-        # This operation is idempotent, so it's safe to call every time.
-        self.client.recreate_collection(
-            collection_name=collection_name,
-            vectors_config=models.VectorParams(
-                size=len(vector),
-                distance=models.Distance.COSINE,
-            ),
-            on_disk_payload=True,
-        )
+        # Create the collection on first insert without wiping existing data.
+        try:
+            self.client.get_collection(collection_name)
+        except Exception:
+            self.client.create_collection(
+                collection_name=collection_name,
+                vectors_config=models.VectorParams(
+                    size=len(vector),
+                    distance=models.Distance.COSINE,
+                ),
+                on_disk_payload=True,
+            )
 
         # Ensure there is an index on the identity payload field for filtering
         try:

--- a/tests/test_vector_store_identity.py
+++ b/tests/test_vector_store_identity.py
@@ -8,10 +8,19 @@ class DummyQdrantClient:
         self.collections = {}
         self.indices = []
 
+    def create_collection(self, collection_name, vectors_config, on_disk_payload=True):
+        self.collections.setdefault(collection_name, [])
+
+    def get_collection(self, collection_name):
+        if collection_name not in self.collections:
+            raise ValueError("Collection not found")
+        return self.collections[collection_name]
+
     def recreate_collection(
         self, collection_name, vectors_config, on_disk_payload=True
     ):
-        self.collections.setdefault(collection_name, [])
+        # Compatibility shim for older tests
+        self.collections[collection_name] = []
 
     def create_payload_index(
         self,


### PR DESCRIPTION
## Summary
- avoid wiping Qdrant collection every time a memory is added
- update DummyQdrantClient to provide create/get collection helpers

## Reasoning
`VectorStore.add_memory` used `recreate_collection`, which deletes any existing vectors. The fix checks for collection existence using `get_collection` and only creates it when missing. Tests required an updated dummy client.

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_6881ff806770832b914a54fb4c408796