### PR TITLE
Improve logging for database and plugin setup

### DIFF
--- a/agent/plugin_loader.py
+++ b/agent/plugin_loader.py
@@ -1,11 +1,13 @@
 # axon/agent/plugin_loader.py
 
+import logging
 import os
 import importlib.util
 import importlib
 import sys
 from dataclasses import dataclass
 from typing import Dict, Callable
+
 
 @dataclass
 class PluginInfo:
@@ -18,14 +20,15 @@ class PluginInfo:
 # This dictionary will hold our loaded plugin metadata
 AVAILABLE_PLUGINS: Dict[str, PluginInfo] = {}
 
+
 def load_plugins(hot_reload: bool = False):
     """
     Scans the 'plugins' directory, imports Python files as modules,
     and registers any functions decorated with @plugin.
     """
     plugin_dirs = [
-        os.path.join(os.path.dirname(__file__), '..', 'plugins'),
-        os.path.join(os.path.dirname(__file__), 'tools'),
+        os.path.join(os.path.dirname(__file__), "..", "plugins"),
+        os.path.join(os.path.dirname(__file__), "tools"),
     ]
 
     for plugin_dir in plugin_dirs:
@@ -33,9 +36,9 @@ def load_plugins(hot_reload: bool = False):
             continue
 
         for filename in os.listdir(plugin_dir):
-            if filename.endswith('.py') and not filename.startswith('__'):
+            if filename.endswith(".py") and not filename.startswith("__"):
                 plugin_path = os.path.join(plugin_dir, filename)
-                if plugin_dir.endswith('plugins'):
+                if plugin_dir.endswith("plugins"):
                     module_name = f"plugins.{filename[:-3]}"
                 else:
                     module_name = f"agent.tools.{filename[:-3]}"
@@ -44,23 +47,28 @@ def load_plugins(hot_reload: bool = False):
                     if module_name in sys.modules and hot_reload:
                         importlib.reload(sys.modules[module_name])
                     else:
-                        spec = importlib.util.spec_from_file_location(module_name, plugin_path)
+                        spec = importlib.util.spec_from_file_location(
+                            module_name, plugin_path
+                        )
                         if spec and spec.loader:
                             plugin_module = importlib.util.module_from_spec(spec)
                             spec.loader.exec_module(plugin_module)
                             sys.modules[module_name] = plugin_module
                         else:
-                            print(f"Could not create spec for plugin: {filename}")
+                            logging.error(
+                                "Could not create spec for plugin: %s", filename
+                            )
                             continue
-                    print(f"Loaded plugin module: {filename}")
-                except Exception as e:
-                    print(f"Failed to load plugin {filename}: {e}")
+                    logging.info("Loaded plugin module: %s", filename)
+                except (ImportError, OSError, SyntaxError, ValueError):
+                    logging.exception("Failed to load plugin %s", filename)
+
 
 def plugin(name: str, description: str = "", usage: str = ""):
     """A decorator to register a function as a plugin."""
 
     def decorator(func: Callable):
-        print(f"Registering plugin: '{name}'")
+        logging.info("Registering plugin: '%s'", name)
         AVAILABLE_PLUGINS[name] = PluginInfo(
             func=func,
             name=name,
@@ -70,4 +78,3 @@ def plugin(name: str, description: str = "", usage: str = ""):
         return func
 
     return decorator
-


### PR DESCRIPTION
## Summary
- replace print statements with `logging` in `MemoryHandler`
- log plugin registration and loading with `logging`
- narrow plugin loading exception handling

## Reasoning
Using Python's logging library gives consistent output and stack traces when database connections fail or plugin modules raise errors. Limiting exceptions during plugin load avoids hiding unexpected issues.

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_688207acc460832ba4029db9703f5d37