### PR TITLE
Add timeout parameter to voice shell

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,11 +157,12 @@ def clipboard_monitor_cmd(seconds: int = 15) -> None:
 
 
 @app.command("voice-shell")
-def voice_shell_cmd() -> None:
+def voice_shell_cmd(timeout: float = 0.0) -> None:
     """Start the hands-free voice shell plugin."""
     from plugins.voice_shell import voice_shell
 
-    voice_shell()
+    t = timeout if timeout > 0 else None
+    voice_shell(timeout=t)
 
 
 @app.command()

--- a/tests/test_cli_voice_shell.py
+++ b/tests/test_cli_voice_shell.py
@@ -1,0 +1,17 @@
+from typer.testing import CliRunner
+import importlib
+import main
+
+
+def test_voice_shell_timeout(monkeypatch):
+    calls = []
+
+    def dummy_voice_shell(*, timeout=None, model_path=None, wakeword="axon"):
+        calls.append(timeout)
+
+    module = importlib.import_module("plugins.voice_shell")
+    monkeypatch.setattr(module, "voice_shell", dummy_voice_shell)
+    runner = CliRunner()
+    result = runner.invoke(main.app, ["voice-shell", "--timeout", "5"])
+    assert result.exit_code == 0
+    assert calls == [5.0]


### PR DESCRIPTION
### Summary
Adds optional `timeout` parameter to `voice_shell` plugin and CLI. Also introduces a CLI test verifying timeout value is passed.

### Problem & Evidence
- `voice_shell` loop previously ran indefinitely relying on `Ctrl+C`.
- No way to stop automatically when running unattended.

### Solution & Alternatives
- Added `timeout` argument to `voice_shell` with message and time limit check.
- Updated CLI command to accept `--timeout` option.
- New test ensures CLI passes timeout.
- Alternative approaches like background thread were considered but added complexity.

### Verification
```bash
make verify  # → 63 passed
```


------
https://chatgpt.com/codex/tasks/task_e_6882146430d0832b8e15c9ba714ab8b4