### PR TITLE
Add MIT license and dependency notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Axon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -112,3 +112,8 @@ reasoning enabled and how to pass the recommended `generate_cfg` settings.
 
 Phases 0 through 4 are complete, including manual cloud prompting and calendar export features. See [phases/roadmap.md](phases/roadmap.md) for the latest status of each phase.
 
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+Third-party package licenses are summarized in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,109 @@
+ Name                       Version          License                                                                        
+ PyJWT                      2.9.0            MIT License                                                                    
+ PyYAML                     6.0.2            MIT License                                                                    
+ Pygments                   2.19.2           BSD License                                                                    
+ aiohappyeyeballs           2.6.1            Python Software Foundation License                                             
+ aiohttp                    3.12.14          Apache-2.0                                                                     
+ aiosignal                  1.4.0            Apache Software License                                                        
+ annotated-types            0.7.0            MIT License                                                                    
+ anyio                      4.9.0            MIT License                                                                    
+ attrs                      25.3.0           UNKNOWN                                                                        
+ certifi                    2025.7.14        Mozilla Public License 2.0 (MPL 2.0)                                           
+ cffi                       1.17.1           MIT License                                                                    
+ charset-normalizer         3.4.2            MIT License                                                                    
+ click                      8.2.1            UNKNOWN                                                                        
+ cryptography               45.0.5           Apache-2.0 OR BSD-3-Clause                                                     
+ dashscope                  1.23.9           Apache Software License                                                        
+ distro                     1.9.0            Apache Software License                                                        
+ eval_type_backport         0.2.2            MIT License                                                                    
+ fastapi                    0.110.3          MIT License                                                                    
+ frozenlist                 1.7.0            Apache-2.0                                                                     
+ grpcio                     1.73.1           Apache Software License                                                        
+ h11                        0.16.0           MIT License                                                                    
+ h2                         4.2.0            MIT License                                                                    
+ hpack                      4.1.0            MIT License                                                                    
+ httpcore                   1.0.9            BSD License                                                                    
+ httptools                  0.6.4            MIT License                                                                    
+ httpx                      0.27.2           BSD License                                                                    
+ hyperframe                 6.1.0            MIT License                                                                    
+ icalendar                  6.3.1            BSD License                                                                    
+ idna                       3.10             BSD License                                                                    
+ iniconfig                  2.1.0            MIT License                                                                    
+ jiter                      0.10.0           MIT License                                                                    
+ json5                      0.12.0           Apache Software License                                                        
+ jsonlines                  4.0.0            BSD License                                                                    
+ jsonschema                 4.25.0           UNKNOWN                                                                        
+ jsonschema-specifications  2025.4.1         UNKNOWN                                                                        
+ keyboard                   0.13.5           MIT License                                                                    
+ markdown-it-py             3.0.0            MIT License                                                                    
+ mdurl                      0.1.2            MIT License                                                                    
+ multidict                  6.6.3            Apache License 2.0                                                             
+ mypy                       1.17.0           MIT License                                                                    
+ mypy_extensions            1.1.0            UNKNOWN                                                                        
+ numpy                      2.3.1            BSD License                                                                    
+ openai                     1.97.0           Apache Software License                                                        
+ packaging                  25.0             Apache Software License; BSD License                                           
+ pathspec                   0.12.1           Mozilla Public License 2.0 (MPL 2.0)                                           
+ pluggy                     1.6.0            MIT License                                                                    
+ plyer                      2.1.0            MIT License                                                                    
+ portalocker                3.2.0            UNKNOWN                                                                        
+ propcache                  0.3.2            Apache Software License                                                        
+ protobuf                   6.31.1           3-Clause BSD License                                                           
+ psycopg2-binary            2.9.10           GNU Library or Lesser General Public License (LGPL)                            
+ pycparser                  2.22             BSD License                                                                    
+ pydantic                   2.11.7           MIT License                                                                    
+ pydantic-settings          2.10.1           MIT License                                                                    
+ pydantic_core              2.33.2           MIT License                                                                    
+ pyperclip                  1.9.0            BSD License                                                                    
+ pypng                      0.20220715.0     MIT License                                                                    
+ pytest                     8.4.1            MIT License                                                                    
+ python-dateutil            2.9.0.post0      Apache Software License; BSD License                                           
+ python-dotenv              1.1.1            BSD License                                                                    
+ qdrant-client              1.15.0           Apache Software License                                                        
+ qrcode                     7.4.2            BSD License                                                                    
+ qwen-agent                 0.0.27           UNKNOWN                                                                        
+ redis                      5.3.0            MIT License                                                                    
+ referencing                0.36.2           UNKNOWN                                                                        
+ regex                      2024.11.6        Apache Software License                                                        
+ requests                   2.32.4           Apache Software License                                                        
+ rich                       14.0.0           MIT License                                                                    
+ rpds-py                    0.26.0           MIT                                                                            
+ ruff                       0.3.7            MIT License                                                                    
+ six                        1.17.0           MIT License                                                                    
+ sniffio                    1.3.1            Apache Software License; MIT License                                           
+ starlette                  0.37.2           BSD License                                                                    
+ tiktoken                   0.9.0            MIT License                                                                    
+                                                                                                                            
+                                             Copyright (c) 2022 OpenAI, Shantanu Jain                                       
+                                                                                                                            
+                                             Permission is hereby granted, free of charge, to any person obtaining a copy   
+                                             of this software and associated documentation files (the "Software"), to deal  
+                                             in the Software without restriction, including without limitation the rights   
+                                             to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+                                             copies of the Software, and to permit persons to whom the Software is          
+                                             furnished to do so, subject to the following conditions:                       
+                                                                                                                            
+                                             The above copyright notice and this permission notice shall be included in all 
+                                             copies or substantial portions of the Software.                                
+                                                                                                                            
+                                             THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+                                             IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+                                             FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+                                             AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+                                             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+                                             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+                                             SOFTWARE.                                                                      
+                                                                                                                            
+ tqdm                       4.67.1           MIT License; Mozilla Public License 2.0 (MPL 2.0)                              
+ typer                      0.9.4            MIT License                                                                    
+ types-PyYAML               6.0.12.20250516  UNKNOWN                                                                        
+ typing-inspection          0.4.1            UNKNOWN                                                                        
+ typing_extensions          4.14.1           UNKNOWN                                                                        
+ tzdata                     2025.2           Apache Software License                                                        
+ urllib3                    2.5.0            UNKNOWN                                                                        
+ uvicorn                    0.27.1           BSD License                                                                    
+ uvloop                     0.21.0           Apache Software License; MIT License                                           
+ watchfiles                 1.1.0            MIT License                                                                    
+ websocket-client           1.8.0            Apache Software License                                                        
+ websockets                 15.0.1           BSD License                                                                    
+ yarl                       1.20.1           Apache Software License                                                        

--- a/phases/readme.md
+++ b/phases/readme.md
@@ -93,5 +93,5 @@ See `ROADMAP.md`.
 
 ## 🔐 License
 
-MIT License
+MIT License (see [LICENSE](../LICENSE))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.poetry]
+license = "MIT"
 name = "axon"
 version = "0.1.0"
 description = "Axon Project"


### PR DESCRIPTION
## Summary
- add an MIT `LICENSE` file
- document the license in README and the phases README
- record licenses of dependencies in `THIRD_PARTY_LICENSES.md`
- note MIT license in `pyproject.toml`

## Reasoning
The repository previously lacked a license file, making its legal status unclear. The maintainer requested to release the project under the MIT License while honoring third‑party licenses. Adding the MIT license and referencing it in documentation clarifies the project's terms. Generating `THIRD_PARTY_LICENSES.md` via `pip-licenses` captures dependency license information for transparency. The license field in `pyproject.toml` makes package metadata consistent.

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_6882253ecb34832bbbc9f1d75d6fe36b