### PR TITLE
Add commit message hook for AI change summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ Your only job: **make it work, prove it works, and explain your reasoning.**
 
 1. Create a branch: `git checkout -b agent/fix-description`
 2. Run preflight: `make verify` or `scripts/preflight.sh`
-3. Fix what fails, commit with <72 char summary
+3. Fix what fails, commit with <72 char summary and include an
+   `AI-Change-Summary` block detailing files touched, tests run, and the
+   rationale for the change
 4. Open PR using template (§6), include reasoning and command outputs
 5. **Never merge if any check fails**
 
@@ -157,6 +159,17 @@ refactor
 ```
 
 **One logical change per commit.** If you fix formatting + logic, make 2 commits.
+
+Every commit must end with an `AI-Change-Summary:` block:
+
+```markdown
+AI-Change-Summary:
+- Files touched: list of files
+- Tests run: command or skipped reason
+- Rationale: short justification
+```
+
+The included `git-hooks/commit-msg` script enforces this format.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ pre-commit install
 The configured hooks execute `ruff`, `black`, `mypy`, `pytest`, `eslint` and
 `tsc` so issues are caught early.
 
+### Commit message contract
+
+Commit messages must end with an `AI-Change-Summary` block listing the files
+touched, tests run, and rationale. Install the provided `git-hooks/commit-msg`
+script so Git enforces this:
+
+```bash
+git config core.hooksPath git-hooks
+```
+
 ## CLI commands
 
 Axon exposes several helper commands via `python main.py`:

--- a/git-hooks/commit-msg
+++ b/git-hooks/commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Enforce AI commit message summary block
+
+set -euo pipefail
+
+msg_file="$1"
+
+if ! grep -q '^AI-Change-Summary:' "$msg_file"; then
+    echo "Error: Commit message must include an AI-Change-Summary block" >&2
+    echo "Example:\n\nAI-Change-Summary:\n- Files touched: foo.py\n- Tests run: make verify\n- Rationale: fix bug" >&2
+    exit 1
+fi
+
+block=$(sed -n '/^AI-Change-Summary:/,/^$/p' "$msg_file" | tail -n +2)
+bullet_count=$(echo "$block" | grep -c '^-' || true)
+if [ "$bullet_count" -lt 3 ]; then
+    echo "Error: AI-Change-Summary block must list files touched, tests run, and rationale" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add git-hooks/commit-msg to enforce AI-Change-Summary block
- document new requirement in README and AGENTS guidelines

## Reasoning
A commit-msg hook ensures every commit from automated agents includes a concise
`AI-Change-Summary` section describing what changed, how it was tested, and why.
This standardizes commit metadata for easier review.

## Testing
- `make verify`
- attempted commit without summary block and observed hook failure


------
https://chatgpt.com/codex/tasks/task_e_688245a42c8c832b9067aa851ee91bd8