### PR TITLE
Automate THIRD_PARTY_LICENSES.md generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,4 @@ Phases 0 through 4 are complete, including manual cloud prompting and calendar e
 
 This project is licensed under the [MIT License](LICENSE).
 Third-party package licenses are summarized in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).
+Run `make licenses` to regenerate this list using **pip-licenses**.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,109 +1,117 @@
- Name                       Version          License                                                                        
- PyJWT                      2.9.0            MIT License                                                                    
- PyYAML                     6.0.2            MIT License                                                                    
- Pygments                   2.19.2           BSD License                                                                    
- aiohappyeyeballs           2.6.1            Python Software Foundation License                                             
- aiohttp                    3.12.14          Apache-2.0                                                                     
- aiosignal                  1.4.0            Apache Software License                                                        
- annotated-types            0.7.0            MIT License                                                                    
- anyio                      4.9.0            MIT License                                                                    
- attrs                      25.3.0           UNKNOWN                                                                        
- certifi                    2025.7.14        Mozilla Public License 2.0 (MPL 2.0)                                           
- cffi                       1.17.1           MIT License                                                                    
- charset-normalizer         3.4.2            MIT License                                                                    
- click                      8.2.1            UNKNOWN                                                                        
- cryptography               45.0.5           Apache-2.0 OR BSD-3-Clause                                                     
- dashscope                  1.23.9           Apache Software License                                                        
- distro                     1.9.0            Apache Software License                                                        
- eval_type_backport         0.2.2            MIT License                                                                    
- fastapi                    0.110.3          MIT License                                                                    
- frozenlist                 1.7.0            Apache-2.0                                                                     
- grpcio                     1.73.1           Apache Software License                                                        
- h11                        0.16.0           MIT License                                                                    
- h2                         4.2.0            MIT License                                                                    
- hpack                      4.1.0            MIT License                                                                    
- httpcore                   1.0.9            BSD License                                                                    
- httptools                  0.6.4            MIT License                                                                    
- httpx                      0.27.2           BSD License                                                                    
- hyperframe                 6.1.0            MIT License                                                                    
- icalendar                  6.3.1            BSD License                                                                    
- idna                       3.10             BSD License                                                                    
- iniconfig                  2.1.0            MIT License                                                                    
- jiter                      0.10.0           MIT License                                                                    
- json5                      0.12.0           Apache Software License                                                        
- jsonlines                  4.0.0            BSD License                                                                    
- jsonschema                 4.25.0           UNKNOWN                                                                        
- jsonschema-specifications  2025.4.1         UNKNOWN                                                                        
- keyboard                   0.13.5           MIT License                                                                    
- markdown-it-py             3.0.0            MIT License                                                                    
- mdurl                      0.1.2            MIT License                                                                    
- multidict                  6.6.3            Apache License 2.0                                                             
- mypy                       1.17.0           MIT License                                                                    
- mypy_extensions            1.1.0            UNKNOWN                                                                        
- numpy                      2.3.1            BSD License                                                                    
- openai                     1.97.0           Apache Software License                                                        
- packaging                  25.0             Apache Software License; BSD License                                           
- pathspec                   0.12.1           Mozilla Public License 2.0 (MPL 2.0)                                           
- pluggy                     1.6.0            MIT License                                                                    
- plyer                      2.1.0            MIT License                                                                    
- portalocker                3.2.0            UNKNOWN                                                                        
- propcache                  0.3.2            Apache Software License                                                        
- protobuf                   6.31.1           3-Clause BSD License                                                           
- psycopg2-binary            2.9.10           GNU Library or Lesser General Public License (LGPL)                            
- pycparser                  2.22             BSD License                                                                    
- pydantic                   2.11.7           MIT License                                                                    
- pydantic-settings          2.10.1           MIT License                                                                    
- pydantic_core              2.33.2           MIT License                                                                    
- pyperclip                  1.9.0            BSD License                                                                    
- pypng                      0.20220715.0     MIT License                                                                    
- pytest                     8.4.1            MIT License                                                                    
- python-dateutil            2.9.0.post0      Apache Software License; BSD License                                           
- python-dotenv              1.1.1            BSD License                                                                    
- qdrant-client              1.15.0           Apache Software License                                                        
- qrcode                     7.4.2            BSD License                                                                    
- qwen-agent                 0.0.27           UNKNOWN                                                                        
- redis                      5.3.0            MIT License                                                                    
- referencing                0.36.2           UNKNOWN                                                                        
- regex                      2024.11.6        Apache Software License                                                        
- requests                   2.32.4           Apache Software License                                                        
- rich                       14.0.0           MIT License                                                                    
- rpds-py                    0.26.0           MIT                                                                            
- ruff                       0.3.7            MIT License                                                                    
- six                        1.17.0           MIT License                                                                    
- sniffio                    1.3.1            Apache Software License; MIT License                                           
- starlette                  0.37.2           BSD License                                                                    
- tiktoken                   0.9.0            MIT License                                                                    
-                                                                                                                            
-                                             Copyright (c) 2022 OpenAI, Shantanu Jain                                       
-                                                                                                                            
-                                             Permission is hereby granted, free of charge, to any person obtaining a copy   
-                                             of this software and associated documentation files (the "Software"), to deal  
-                                             in the Software without restriction, including without limitation the rights   
-                                             to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
-                                             copies of the Software, and to permit persons to whom the Software is          
-                                             furnished to do so, subject to the following conditions:                       
-                                                                                                                            
-                                             The above copyright notice and this permission notice shall be included in all 
-                                             copies or substantial portions of the Software.                                
-                                                                                                                            
-                                             THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
-                                             IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
-                                             FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
-                                             AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
-                                             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
-                                             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
-                                             SOFTWARE.                                                                      
-                                                                                                                            
- tqdm                       4.67.1           MIT License; Mozilla Public License 2.0 (MPL 2.0)                              
- typer                      0.9.4            MIT License                                                                    
- types-PyYAML               6.0.12.20250516  UNKNOWN                                                                        
- typing-inspection          0.4.1            UNKNOWN                                                                        
- typing_extensions          4.14.1           UNKNOWN                                                                        
- tzdata                     2025.2           Apache Software License                                                        
- urllib3                    2.5.0            UNKNOWN                                                                        
- uvicorn                    0.27.1           BSD License                                                                    
- uvloop                     0.21.0           Apache Software License; MIT License                                           
- watchfiles                 1.1.0            MIT License                                                                    
- websocket-client           1.8.0            Apache Software License                                                        
- websockets                 15.0.1           BSD License                                                                    
- yarl                       1.20.1           Apache Software License                                                        
+ Name                       Version       License                                                                        
+ PyJWT                      2.9.0         MIT License                                                                    
+ PyYAML                     6.0.2         MIT License                                                                    
+ Pygments                   2.19.2        BSD License                                                                    
+ aiohappyeyeballs           2.6.1         Python Software Foundation License                                             
+ aiohttp                    3.12.14       Apache-2.0                                                                     
+ aiosignal                  1.4.0         Apache Software License                                                        
+ annotated-types            0.7.0         MIT License                                                                    
+ anyio                      4.9.0         MIT License                                                                    
+ attrs                      25.3.0        UNKNOWN                                                                        
+ black                      24.10.0       MIT License                                                                    
+ certifi                    2025.7.14     Mozilla Public License 2.0 (MPL 2.0)                                           
+ cffi                       1.17.1        MIT License                                                                    
+ cfgv                       3.4.0         MIT License                                                                    
+ charset-normalizer         3.4.2         MIT License                                                                    
+ click                      8.2.1         UNKNOWN                                                                        
+ cryptography               45.0.5        Apache-2.0 OR BSD-3-Clause                                                     
+ dashscope                  1.23.9        Apache Software License                                                        
+ distlib                    0.4.0         Python Software Foundation License                                             
+ distro                     1.9.0         Apache Software License                                                        
+ eval_type_backport         0.2.2         MIT License                                                                    
+ fastapi                    0.110.3       MIT License                                                                    
+ filelock                   3.18.0        The Unlicense (Unlicense)                                                      
+ frozenlist                 1.7.0         Apache-2.0                                                                     
+ grpcio                     1.73.1        Apache Software License                                                        
+ h11                        0.16.0        MIT License                                                                    
+ h2                         4.2.0         MIT License                                                                    
+ hpack                      4.1.0         MIT License                                                                    
+ httpcore                   1.0.9         BSD License                                                                    
+ httptools                  0.6.4         MIT License                                                                    
+ httpx                      0.27.2        BSD License                                                                    
+ hyperframe                 6.1.0         MIT License                                                                    
+ icalendar                  6.3.1         BSD License                                                                    
+ identify                   2.6.12        MIT                                                                            
+ idna                       3.10          BSD License                                                                    
+ iniconfig                  2.1.0         MIT License                                                                    
+ jiter                      0.10.0        MIT License                                                                    
+ json5                      0.12.0        Apache Software License                                                        
+ jsonlines                  4.0.0         BSD License                                                                    
+ jsonschema                 4.25.0        UNKNOWN                                                                        
+ jsonschema-specifications  2025.4.1      UNKNOWN                                                                        
+ keyboard                   0.13.5        MIT License                                                                    
+ markdown-it-py             3.0.0         MIT License                                                                    
+ mdurl                      0.1.2         MIT License                                                                    
+ multidict                  6.6.3         Apache License 2.0                                                             
+ mypy                       1.17.0        MIT License                                                                    
+ mypy_extensions            1.1.0         UNKNOWN                                                                        
+ nodeenv                    1.9.1         BSD License                                                                    
+ numpy                      2.3.1         BSD License                                                                    
+ openai                     1.97.0        Apache Software License                                                        
+ packaging                  25.0          Apache Software License; BSD License                                           
+ pathspec                   0.12.1        Mozilla Public License 2.0 (MPL 2.0)                                           
+ platformdirs               4.3.8         MIT License                                                                    
+ pluggy                     1.6.0         MIT License                                                                    
+ plyer                      2.1.0         MIT License                                                                    
+ portalocker                3.2.0         UNKNOWN                                                                        
+ pre-commit                 3.8.0         MIT License                                                                    
+ propcache                  0.3.2         Apache Software License                                                        
+ protobuf                   6.31.1        3-Clause BSD License                                                           
+ psycopg2-binary            2.9.10        GNU Library or Lesser General Public License (LGPL)                            
+ pycparser                  2.22          BSD License                                                                    
+ pydantic                   2.11.7        MIT License                                                                    
+ pydantic-settings          2.10.1        MIT License                                                                    
+ pydantic_core              2.33.2        MIT License                                                                    
+ pyperclip                  1.9.0         BSD License                                                                    
+ pypng                      0.20220715.0  MIT License                                                                    
+ pytest                     8.4.1         MIT License                                                                    
+ python-dateutil            2.9.0.post0   Apache Software License; BSD License                                           
+ python-dotenv              1.1.1         BSD License                                                                    
+ qdrant-client              1.15.0        Apache Software License                                                        
+ qrcode                     7.4.2         BSD License                                                                    
+ qwen-agent                 0.0.27        UNKNOWN                                                                        
+ redis                      5.3.0         MIT License                                                                    
+ referencing                0.36.2        UNKNOWN                                                                        
+ regex                      2024.11.6     Apache Software License                                                        
+ requests                   2.32.4        Apache Software License                                                        
+ rich                       14.0.0        MIT License                                                                    
+ rpds-py                    0.26.0        MIT                                                                            
+ ruff                       0.3.7         MIT License                                                                    
+ six                        1.17.0        MIT License                                                                    
+ sniffio                    1.3.1         Apache Software License; MIT License                                           
+ starlette                  0.37.2        BSD License                                                                    
+ tiktoken                   0.9.0         MIT License                                                                    
+                                                                                                                         
+                                          Copyright (c) 2022 OpenAI, Shantanu Jain                                       
+                                                                                                                         
+                                          Permission is hereby granted, free of charge, to any person obtaining a copy   
+                                          of this software and associated documentation files (the "Software"), to deal  
+                                          in the Software without restriction, including without limitation the rights   
+                                          to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+                                          copies of the Software, and to permit persons to whom the Software is          
+                                          furnished to do so, subject to the following conditions:                       
+                                                                                                                         
+                                          The above copyright notice and this permission notice shall be included in all 
+                                          copies or substantial portions of the Software.                                
+                                                                                                                         
+                                          THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+                                          IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+                                          FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+                                          AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+                                          LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+                                          OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+                                          SOFTWARE.                                                                      
+                                                                                                                         
+ tqdm                       4.67.1        MIT License; Mozilla Public License 2.0 (MPL 2.0)                              
+ typer                      0.9.4         MIT License                                                                    
+ typing-inspection          0.4.1         UNKNOWN                                                                        
+ typing_extensions          4.14.1        UNKNOWN                                                                        
+ tzdata                     2025.2        Apache Software License                                                        
+ urllib3                    2.5.0         UNKNOWN                                                                        
+ uvicorn                    0.27.1        BSD License                                                                    
+ uvloop                     0.21.0        Apache Software License; MIT License                                           
+ virtualenv                 20.32.0       MIT License                                                                    
+ watchfiles                 1.1.0         MIT License                                                                    
+ websocket-client           1.8.0         Apache Software License                                                        
+ websockets                 15.0.1        BSD License                                                                    
+ yarl                       1.20.1        Apache Software License                                                        

--- a/makefile
+++ b/makefile
@@ -1,16 +1,20 @@
-.PHONY: verify lint format type test frontend install clean help
+.PHONY: verify lint format type test frontend install licenses clean help
 
 # Default target when just running 'make'
 all: verify
 
 # Main verification pipeline - what agents should run
-verify: install lint type test
+verify: install licenses lint type test
 	@echo "✅ All checks passed - ready to commit"
 
 # Individual components
 install:
 	@echo "📦 Installing dependencies..."
 	poetry install --no-interaction --no-root
+
+licenses:
+	@echo "📄 Generating THIRD_PARTY_LICENSES.md..."
+	poetry run python scripts/generate_third_party_licenses.py
 
 lint:
 	@echo "🔍 Linting and formatting..."
@@ -67,6 +71,7 @@ help:
 	@echo "  lint        - Run ruff linter and formatter"
 	@echo "  type        - Run mypy type checker"
 	@echo "  test        - Run pytest suite"
+	@echo "  licenses    - Update THIRD_PARTY_LICENSES.md"
 	@echo "  frontend    - Run frontend linting"
 	@echo "  quick       - Fast iteration: format + first test failure"
 	@echo "  clean       - Remove cache files and node_modules"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1647,6 +1647,25 @@ files = [
 ]
 
 [[package]]
+name = "pip-licenses"
+version = "5.0.0"
+description = "Dump the software license list of Python packages installed with pip."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pip_licenses-5.0.0-py3-none-any.whl", hash = "sha256:82c83666753efb86d1af1c405c8ab273413eb10d6689c218df2f09acf40e477d"},
+    {file = "pip_licenses-5.0.0.tar.gz", hash = "sha256:0633a1f9aab58e5a6216931b0e1d5cdded8bcc2709ff563674eb0e2ff9e77e8e"},
+]
+
+[package.dependencies]
+prettytable = ">=2.3.0"
+tomli = ">=2"
+
+[package.extras]
+dev = ["autopep8", "black", "docutils", "isort", "mypy", "pip-tools", "pypandoc", "pytest-cov", "pytest-pycodestyle", "pytest-runner", "tomli-w", "twine", "wheel"]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -1735,6 +1754,24 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
+
+[[package]]
+name = "prettytable"
+version = "3.16.0"
+description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa"},
+    {file = "prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "pytest-lazy-fixtures"]
 
 [[package]]
 name = "propcache"
@@ -6451,7 +6488,6 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -6809,6 +6845,18 @@ files = [
 anyio = ">=3.0.0"
 
 [[package]]
+name = "wcwidth"
+version = "0.2.13"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
+]
+
+[[package]]
 name = "websocket-client"
 version = "1.8.0"
 description = "WebSocket client for Python with low level API options"
@@ -7026,4 +7074,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "6181c0171c8e1707ee1d617c56b6ac6a3c516fd4895f41a83702cff10552a41a"
+content-hash = "872443c324ae9df091e9054007eb1c74198d2df67c7757423c4abd5ed90d2403"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ mypy = "^1.9.0"
 pytest = "^8.1.1"
 pre-commit = "^3.7.0"
 black = "^24.4.2"
+pip-licenses = "^5.0.0"
 
 [tool.mypy]
 explicit_package_bases = true

--- a/scripts/generate_third_party_licenses.py
+++ b/scripts/generate_third_party_licenses.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""Generate THIRD_PARTY_LICENSES.md using pip-licenses."""
+
+import pathlib
+import subprocess
+import sys
+
+OUTPUT_FILE = pathlib.Path(__file__).resolve().parent.parent / "THIRD_PARTY_LICENSES.md"
+
+
+def main() -> None:
+    cmd = [sys.executable, "-m", "piplicenses", "--format=plain"]
+    with OUTPUT_FILE.open("w") as f:
+        subprocess.run(cmd, check=True, stdout=f)
+    print(f"Wrote licenses to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -110,6 +110,9 @@ main() {
     
     # Install dependencies
     run_check "Installing Python dependencies" "poetry install --no-interaction --no-root"
+
+    # Generate third-party license summary
+    run_check "Updating THIRD_PARTY_LICENSES.md" "poetry run python scripts/generate_third_party_licenses.py"
     
     # Linting and formatting
     run_check "Running ruff linter" "poetry run ruff check . --fix"


### PR DESCRIPTION
## Summary
- add `pip-licenses` as a development dependency
- script `generate_third_party_licenses.py` writes THIRD_PARTY_LICENSES.md
- run license generation in Makefile `verify` and preflight.sh
- document `make licenses` in README

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_688251b59290832b8f5510ee0a227bbf