### PR TITLE
Add make check/fix and CI lint guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,12 @@ jobs:
           virtualenvs-in-project: true
       - name: Validate lock file
         run: poetry lock --no-update
-      - name: Run verification
-        run: make verify
+      - name: Run checks
+        run: make check
+      - name: pre-commit
+        run: |
+          poetry run pre-commit run --all-files --hook-stage manual --show-diff-on-failure
+          git diff --exit-code
 
   frontend:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Please run the formatter before pushing changes so CI passes.
+
+```bash
+make fix
+```
+
+Running `make fix` formats the codebase using Ruff and other tools. The CI pipeline executes `make check` to verify formatting without writing files. If formatting or lint fails, CI will reject the commit.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,17 +30,17 @@ qrcode = "^7.4"
 redis = "^5.0.0"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.3.2"
-mypy = "^1.9.0"
-pytest = "^8.1.1"
-pre-commit = "^3.7.0"
-black = "^24.4.2"
-pip-licenses = "^5.0.0"
+ruff = "==0.3.2"
+mypy = "==1.9.0"
+pytest = "==8.1.1"
+pre-commit = "==3.7.0"
+black = "==24.4.2"
+pip-licenses = "==5.0.0"
 
 [tool.ruff]
 target-version = "py311"
 line-length = 100
-fix = true
+fix = false
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP"]

--- a/tools/ensure_small_diff.py
+++ b/tools/ensure_small_diff.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+
+
+def run(cmd: list[str]) -> list[str]:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(f"Failed to run {' '.join(cmd)}", file=sys.stderr)
+        sys.exit(1)
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    base_files = set(run(["git", "diff", "--name-only", "main...HEAD"]))
+    modified = set(run(["git", "ls-files", "-m"]))
+    extra = [f for f in modified if f not in base_files]
+    if len(extra) > 100:
+        print(f"\u274c tooling modified {len(extra)} unrelated files")
+        for f in extra[:10]:
+            print(f"  {f}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `make check` and `make fix` to separate verify and formatting steps
- run checks in CI instead of auto-fixing
- pin dev tool versions in `pyproject.toml`
- ensure pre-commit runs in diff-only mode on CI
- document running `make fix` before pushing
- add helper script to detect large diffs

## Testing
- `poetry lock`
- `make check` *(fails: 41 files would be reformatted, 2 tests failing)*
- `python tools/ensure_small_diff.py`

------
https://chatgpt.com/codex/tasks/task_e_68829429d4cc832ba638e9ac2053dcb6