### PR TITLE
Add plugin v2 loader and manifests

### DIFF
--- a/axon/config/settings.py
+++ b/axon/config/settings.py
@@ -160,7 +160,7 @@ def validate_or_die() -> Settings:
         for err in exc.error.errors():
             loc = ".".join(str(p) for p in err["loc"])
             print(f"- {loc}: {err['msg']}")
-        raise SystemExit(1)
+        raise SystemExit(1) from None
 
 
 def schema_json() -> str:

--- a/axon/plugins/loader.py
+++ b/axon/plugins/loader.py
@@ -2,34 +2,28 @@ from __future__ import annotations
 
 import importlib.util
 import logging
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from time import monotonic
 from typing import Any
 
-import yaml
-from pydantic import BaseModel, ValidationError, create_model
+from pydantic import BaseModel, create_model
 
 from .base import Plugin
+from .manifest import Manifest, load_manifest
 from .permissions import Permission
 
 logger = logging.getLogger(__name__)
 
 
-class ManifestModel(BaseModel):
-    name: str
-    version: str
-    description: str
-    permissions: list[Permission] = []
-    config_schema: dict[str, str] | None = None
-
-
 class AuditLog:
-    """Simple structured audit logger."""
+    """Structured audit logger for plugin actions."""
 
-    def __init__(self, plugin: str, action: str):
+    def __init__(self, plugin: str, action: str, redacted: bool = False) -> None:
         self.plugin = plugin
         self.action = action
+        self.redacted = redacted
         self.start = 0.0
 
     def __enter__(self) -> None:
@@ -38,10 +32,10 @@ class AuditLog:
     def __exit__(self, exc_type, exc, tb) -> None:
         duration = monotonic() - self.start
         logger.info(
-            "plugin-action",
+            "plugin-%s",
+            self.action,
             extra={
                 "plugin": self.plugin,
-                "action": self.action,
                 "success": exc is None,
                 "duration": duration,
             },
@@ -49,77 +43,93 @@ class AuditLog:
 
 
 class PluginLoader:
-    """Load and manage plugins."""
+    """Discover, validate and safely execute plugins."""
 
     def __init__(
         self,
         plugin_dir: str | Path = "plugins",
-        deny: Iterable[Permission] | None = None,
+        *,
+        deny: set[Permission] | None = None,
         dry_run: bool = False,
     ) -> None:
         self.plugin_dir = Path(plugin_dir)
-        self.deny = set(deny or [])
+        self.deny = deny or set()
         self.dry_run = dry_run
         self.plugins: dict[str, Plugin] = {}
-        self.manifests: dict[str, ManifestModel] = {}
-
-    def _load_manifest(self, path: Path) -> ManifestModel:
-        if not path.exists():
-            raise FileNotFoundError(f"Missing manifest for plugin {path.stem}")
-        data = yaml.safe_load(path.read_text()) or {}
-        try:
-            manifest = ManifestModel.model_validate(data)
-        except ValidationError as exc:  # pragma: no cover - validation
-            raise ValueError(f"Invalid manifest {path}: {exc}") from exc
-        return manifest
+        self.manifests: dict[str, Manifest] = {}
 
     def discover(self, configs: Mapping[str, Mapping[str, Any]] | None = None) -> None:
         configs = configs or {}
         for py_file in self.plugin_dir.glob("*.py"):
             if py_file.name.startswith("__"):
                 continue
-            name = py_file.stem
-            manifest = self._load_manifest(py_file.with_suffix(".yaml"))
+            yaml_path = py_file.with_suffix(".yaml")
+            toml_path = py_file.with_suffix(".toml")
+            if yaml_path.exists():
+                manifest_path = yaml_path
+            elif toml_path.exists():
+                manifest_path = toml_path
+            else:
+                raise FileNotFoundError(f"Missing manifest for plugin {py_file.stem}")
+            manifest = load_manifest(manifest_path)
             self.manifests[manifest.name] = manifest
-            if self.dry_run:
-                continue
             if self.deny:
                 removed = [p for p in manifest.permissions if p in self.deny]
                 if removed:
                     manifest.permissions = [p for p in manifest.permissions if p not in self.deny]
                     logger.info(
-                        "permission-stripped",
-                        extra={"plugin": name, "removed": removed},
+                        "permission-stripped", extra={"plugin": manifest.name, "removed": removed}
                     )
-            spec = importlib.util.spec_from_file_location(f"plugins.{name}", py_file)
-            if spec and spec.loader:
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-            else:  # pragma: no cover - missing loader
-                raise ImportError(f"Cannot load plugin {name}")
-            plugin_cls = getattr(module, "PLUGIN_CLASS", None)
-            if not plugin_cls or not issubclass(plugin_cls, Plugin):
-                raise TypeError(f"Plugin {name} missing PLUGIN_CLASS")
-            plugin = plugin_cls(manifest.model_dump())
+            module_name, cls_name = manifest.entrypoint.split(":")
+            module_file = self.plugin_dir / f"{module_name}.py"
+            spec = importlib.util.spec_from_file_location(module_name, module_file)
+            if not spec or not spec.loader:
+                raise ImportError(f"Cannot load module {module_name}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            plugin_cls = getattr(module, cls_name)
+            if not issubclass(plugin_cls, Plugin):
+                raise TypeError(f"{manifest.entrypoint} is not a Plugin")
+            plugin = plugin_cls(manifest, dry_run=self.dry_run)
             schema = manifest.config_schema
             cfg_model: type[BaseModel] | None = None
             if schema:
                 type_map = {"int": int, "str": str, "bool": bool, "float": float}
                 fields = {k: (type_map[v], ...) for k, v in schema.items()}
-                cfg_model = create_model(f"Cfg_{name}", **fields)  # type: ignore[call-overload]
-            cfg_data = configs.get(name)
-            if cfg_model and cfg_data is not None:
-                cfg = cfg_model(**cfg_data)
-            else:
-                cfg = None
+                cfg_model = create_model(f"Cfg_{manifest.name}", **fields)  # type: ignore[call-overload]
+            cfg_data = configs.get(manifest.name)
+            cfg = cfg_model(**cfg_data) if cfg_model and cfg_data is not None else None
             plugin.load(cfg)
             self.plugins[manifest.name] = plugin
             logger.info("plugin-loaded", extra={"plugin": manifest.name})
 
-    def execute(self, name: str, data: Any) -> Any:
+    def execute(
+        self, name: str, data: Mapping[str, Any], *, timeout: float | None = None, retries: int = 0
+    ) -> Any:
         plugin = self.plugins[name]
-        with AuditLog(name, "execute"):
-            return plugin.execute(data)
+
+        def call() -> Any:
+            model = plugin.input_model(**data) if isinstance(data, Mapping) else data
+            result = plugin.execute(model)
+            return (
+                plugin.output_model.model_validate(result)
+                if isinstance(result, Mapping)
+                else result
+            )
+
+        attempt = 0
+        while True:
+            try:
+                with AuditLog(name, "execute"):
+                    if timeout is None:
+                        return call()
+                    with ThreadPoolExecutor(max_workers=1) as ex:
+                        future = ex.submit(call)
+                        return future.result(timeout=timeout)
+            except Exception as exc:
+                attempt += 1
+                if attempt > retries:
+                    raise exc
 
     def shutdown_all(self) -> None:
         for name, plugin in self.plugins.items():

--- a/axon/plugins/manifest.py
+++ b/axon/plugins/manifest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from .permissions import Permission
+
+
+class Manifest(BaseModel):
+    """Plugin manifest data."""
+
+    name: str
+    version: str
+    description: str
+    entrypoint: str
+    permissions: list[Permission] = []
+    config_schema: dict[str, str] | None = None
+
+
+def load_manifest(path: Path) -> Manifest:
+    """Load and validate a plugin manifest."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Missing manifest: {path}")
+
+    if path.suffix == ".yaml":
+        raw: Any = yaml.safe_load(path.read_text())
+    elif path.suffix == ".toml":
+        raw = tomllib.loads(path.read_text())
+    else:  # pragma: no cover - unsupported ext
+        raise ValueError(f"Unsupported manifest format: {path.suffix}")
+
+    try:
+        return Manifest.model_validate(raw or {})
+    except ValidationError as exc:
+        raise ValueError(f"Invalid manifest {path}: {exc}") from exc

--- a/axon/plugins/permissions.py
+++ b/axon/plugins/permissions.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 from enum import Enum
+
+logger = logging.getLogger(__name__)
 
 
 class Permission(str, Enum):
@@ -10,3 +13,12 @@ class Permission(str, Enum):
     FS_WRITE = "fs.write"
     NET_HTTP = "net.http"
     PROCESS_SPAWN = "process.spawn"
+
+
+def guard(permission: Permission, granted: set[Permission], *, dry_run: bool = False) -> None:
+    """Assert permission is granted and handle dry-run."""
+    if permission not in granted:
+        logger.error("permission denied", extra={"permission": permission})
+        raise PermissionError(f"Permission '{permission}' not granted")
+    if dry_run:
+        logger.info("dry-run: %s", permission)

--- a/plugins/clipboard_monitor.yaml
+++ b/plugins/clipboard_monitor.yaml
@@ -1,4 +1,5 @@
 name: clipboard_monitor
-version: "1.0"
+version: "2.0"
 description: Watch clipboard for updates for a few seconds
+entrypoint: clipboard_monitor:ClipboardMonitorPlugin
 permissions: []

--- a/plugins/echo.py
+++ b/plugins/echo.py
@@ -1,11 +1,17 @@
-# axon/plugins/echo.py
-
-from typing import Any
+from __future__ import annotations
 
 from pydantic import BaseModel
 from qwen_agent.tools.base import BaseTool, register_tool
 
 from axon.plugins.base import Plugin
+
+
+class EchoInput(BaseModel):
+    text: str
+
+
+class EchoOutput(BaseModel):
+    text: str
 
 
 @register_tool("echo")
@@ -14,34 +20,29 @@ class EchoTool(BaseTool):
 
     description = "Echo back the provided text"
     parameters = [
-        {
-            "name": "text",
-            "type": "string",
-            "description": "Text to echo back",
-            "required": True,
-        }
+        {"name": "text", "type": "string", "description": "Text to echo back", "required": True}
     ]
 
-    def call(self, params: Any, **kwargs) -> str:
+    def call(self, params: dict, **kwargs) -> str:
         args = self._verify_json_format_args(params)
         return args["text"]
 
 
-class EchoPlugin(Plugin):
+class EchoPlugin(Plugin[EchoInput, EchoOutput]):
     """Simple echo plugin."""
 
-    def load(self, config: BaseModel | None) -> None:  # pragma: no cover - no op
+    input_model = EchoInput
+    output_model = EchoOutput
+
+    def load(self, config: BaseModel | None) -> None:  # pragma: no cover - simple
         return
 
-    def describe(self) -> dict[str, Any]:
-        return {
-            "name": self.manifest["name"],
-            "description": self.manifest["description"],
-        }
+    def describe(self) -> dict[str, str]:
+        return {"name": self.manifest.name, "description": self.manifest.description}
 
-    def execute(self, data: Any) -> str:
+    def execute(self, data: EchoInput) -> EchoOutput:
         tool = EchoTool()
-        return tool.call({"text": data["text"]})
+        return EchoOutput(text=tool.call({"text": data.text}))
 
 
 PLUGIN_CLASS = EchoPlugin

--- a/plugins/echo.yaml
+++ b/plugins/echo.yaml
@@ -1,4 +1,5 @@
 name: echo
-version: "1.0"
+version: "2.0"
 description: Echo back the provided text
+entrypoint: echo:EchoPlugin
 permissions: []

--- a/plugins/fact_goal.py
+++ b/plugins/fact_goal.py
@@ -1,4 +1,4 @@
-from typing import Any
+from __future__ import annotations
 
 from pydantic import BaseModel
 from qwen_agent.tools.base import BaseTool, register_tool
@@ -7,60 +7,50 @@ from agent.plugin_context import context
 from axon.plugins.base import Plugin
 
 
+class GoalInput(BaseModel):
+    key: str
+    value: str
+    goal: str
+
+
+class GoalOutput(BaseModel):
+    result: str
+
+
 @register_tool("remember_goal")
 class RememberGoal(BaseTool):
     """Store a fact and record a goal."""
 
     description = "Store a fact and log a goal"
     parameters = [
-        {
-            "name": "key",
-            "type": "string",
-            "description": "Fact key",
-            "required": True,
-        },
-        {
-            "name": "value",
-            "type": "string",
-            "description": "Fact value",
-            "required": True,
-        },
-        {
-            "name": "goal",
-            "type": "string",
-            "description": "Goal text to record",
-            "required": True,
-        },
+        {"name": "key", "type": "string", "description": "Fact key", "required": True},
+        {"name": "value", "type": "string", "description": "Fact value", "required": True},
+        {"name": "goal", "type": "string", "description": "Goal text to record", "required": True},
     ]
 
-    def call(self, params: Any, **kwargs) -> str:
+    def call(self, params: dict, **kwargs) -> str:
         args = self._verify_json_format_args(params)
         context.add_fact(args["key"], args["value"])
         context.add_goal(args["goal"])
         return "ok"
 
 
-class RememberGoalPlugin(Plugin):
+class RememberGoalPlugin(Plugin[GoalInput, GoalOutput]):
     """Demo plugin that saves a fact then records a goal."""
 
-    def load(self, config: BaseModel | None) -> None:  # pragma: no cover - no op
+    input_model = GoalInput
+    output_model = GoalOutput
+
+    def load(self, config: BaseModel | None) -> None:  # pragma: no cover - simple
         return
 
-    def describe(self) -> dict[str, Any]:
-        return {
-            "name": self.manifest["name"],
-            "description": self.manifest["description"],
-        }
+    def describe(self) -> dict[str, str]:
+        return {"name": self.manifest.name, "description": self.manifest.description}
 
-    def execute(self, data: Any) -> str:
+    def execute(self, data: GoalInput) -> GoalOutput:
         tool = RememberGoal()
-        return tool.call(
-            {
-                "key": data["key"],
-                "value": data["value"],
-                "goal": data["goal"],
-            }
-        )
+        result = tool.call({"key": data.key, "value": data.value, "goal": data.goal})
+        return GoalOutput(result=result)
 
 
 PLUGIN_CLASS = RememberGoalPlugin

--- a/plugins/fact_goal.yaml
+++ b/plugins/fact_goal.yaml
@@ -1,4 +1,5 @@
 name: remember_goal
-version: "1.0"
+version: "2.0"
 description: Store a fact and log a goal
+entrypoint: fact_goal:RememberGoalPlugin
 permissions: []

--- a/plugins/system_info.py
+++ b/plugins/system_info.py
@@ -1,4 +1,4 @@
-# axon/plugins/system_info.py
+from __future__ import annotations
 
 import platform
 from typing import Any
@@ -9,6 +9,14 @@ from qwen_agent.tools.base import BaseTool, register_tool
 from axon.plugins.base import Plugin
 
 
+class EmptyInput(BaseModel):
+    pass
+
+
+class InfoOutput(BaseModel):
+    text: str
+
+
 @register_tool("get_os_version")
 class GetOSVersion(BaseTool):
     """Return the host operating system version."""
@@ -16,27 +24,26 @@ class GetOSVersion(BaseTool):
     description = "Return the host operating system version"
     parameters: list[Any] = []
 
-    def call(self, params: Any, **kwargs) -> str:
-        # No parameters needed, just verify empty input
+    def call(self, params: dict, **kwargs) -> str:
         self._verify_json_format_args(params)
         return f"The current OS is: {platform.system()} {platform.release()}"
 
 
-class SystemInfoPlugin(Plugin):
+class SystemInfoPlugin(Plugin[EmptyInput, InfoOutput]):
     """Plugin returning OS information."""
 
-    def load(self, config: BaseModel | None) -> None:  # pragma: no cover - no op
+    input_model = EmptyInput
+    output_model = InfoOutput
+
+    def load(self, config: BaseModel | None) -> None:  # pragma: no cover - simple
         return
 
-    def describe(self) -> dict[str, Any]:
-        return {
-            "name": self.manifest["name"],
-            "description": self.manifest["description"],
-        }
+    def describe(self) -> dict[str, str]:
+        return {"name": self.manifest.name, "description": self.manifest.description}
 
-    def execute(self, data: Any) -> str:
+    def execute(self, data: EmptyInput) -> InfoOutput:
         tool = GetOSVersion()
-        return tool.call({})
+        return InfoOutput(text=tool.call({}))
 
 
 PLUGIN_CLASS = SystemInfoPlugin

--- a/plugins/system_info.yaml
+++ b/plugins/system_info.yaml
@@ -1,4 +1,5 @@
 name: get_os_version
-version: "1.0"
+version: "2.0"
 description: Return the host operating system version
+entrypoint: system_info:SystemInfoPlugin
 permissions: []

--- a/plugins/voice_shell.yaml
+++ b/plugins/voice_shell.yaml
@@ -1,5 +1,6 @@
 name: voice_shell
-version: "1.0"
+version: "2.0"
 description: Start a hands-free voice shell
+entrypoint: voice_shell:VoiceShellPlugin
 permissions:
   - process.spawn

--- a/tests/plugins/test_loader.py
+++ b/tests/plugins/test_loader.py
@@ -4,33 +4,56 @@ import logging
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
 
 from axon.plugins.loader import PluginLoader
 from axon.plugins.permissions import Permission
 
 
+def yaml(data: dict) -> str:
+    import yaml as _yaml
+
+    return _yaml.safe_dump(data)
+
+
 def make_plugin(
-    tmp_path: Path, name: str, perms: list[str] | None = None, schema: dict[str, str] | None = None
+    tmp_path: Path, name: str, *, perms: list[str] | None = None, sleep: float | None = None
 ) -> None:
     py = tmp_path / f"{name}.py"
     py.write_text(
-        """
+        f"""
+import time
+from pathlib import Path
 from pydantic import BaseModel
 from axon.plugins.base import Plugin
 from axon.plugins.permissions import Permission
 
-class TestPlugin(Plugin):
+class InModel(BaseModel):
+    text: str = "hi"
+
+class OutModel(BaseModel):
+    text: str
+
+class TestPlugin(Plugin[InModel, OutModel]):
+    input_model = InModel
+    output_model = OutModel
+
     def load(self, config: BaseModel | None) -> None:
-        self.config = config
+        pass
 
     def describe(self) -> dict[str, str]:
-        return {"name": self.manifest['name']}
+        return {{"name": self.manifest.name}}
 
-    def execute(self, data):
-        if Permission.FS_WRITE in self.permissions:
-            self.check_permission(Permission.FS_WRITE)
-        return "ok"
+    def execute(self, data: InModel) -> OutModel:
+        if {sleep is not None}:
+            time.sleep({sleep or 0})
+        if {'fs.write' in (perms or [])}:
+            self.require(Permission.FS_WRITE)
+            if not self.dry_run:
+                Path("{name}.out").write_text(data.text)
+        return OutModel(text=data.text)
+
+    def shutdown(self) -> None:
+        self.closed = True
 
 PLUGIN_CLASS = TestPlugin
 """
@@ -39,17 +62,10 @@ PLUGIN_CLASS = TestPlugin
         "name": name,
         "version": "1.0",
         "description": name,
+        "entrypoint": f"{name}:TestPlugin",
         "permissions": perms or [],
     }
-    if schema:
-        manifest["config_schema"] = schema  # type: ignore[assignment]
     (tmp_path / f"{name}.yaml").write_text(yaml(manifest))
-
-
-def yaml(data: dict) -> str:
-    import yaml as _yaml
-
-    return _yaml.safe_dump(data)
 
 
 def test_manifest_required(tmp_path: Path):
@@ -59,28 +75,52 @@ def test_manifest_required(tmp_path: Path):
         loader.discover()
 
 
+def test_invalid_manifest(tmp_path: Path):
+    make_plugin(tmp_path, "p")
+    (tmp_path / "p.yaml").write_text("name: p")
+    loader = PluginLoader(plugin_dir=tmp_path)
+    with pytest.raises(ValueError):
+        loader.discover()
+
+
 def test_permission_denied(tmp_path: Path, caplog: pytest.LogCaptureFixture):
-    make_plugin(tmp_path, "p", ["fs.write"])
-    caplog.set_level(logging.INFO)
+    make_plugin(tmp_path, "p", perms=["fs.write"])
     loader = PluginLoader(plugin_dir=tmp_path, deny={Permission.FS_WRITE})
     loader.discover()
-    assert "permission-stripped" in caplog.text
-    assert loader.execute("p", {}) == "ok"
+    caplog.set_level(logging.INFO)
     with pytest.raises(PermissionError):
-        loader.plugins["p"].check_permission(Permission.FS_WRITE)
+        loader.execute("p", {"text": "x"})
+    assert any(r.levelno <= logging.ERROR for r in caplog.records)
 
 
-def test_plugin_execute_logged(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+def test_timeout_enforced(tmp_path: Path):
+    make_plugin(tmp_path, "p", sleep=0.5)
+    loader = PluginLoader(plugin_dir=tmp_path)
+    loader.discover()
+    with pytest.raises(TimeoutError):
+        loader.execute("p", {}, timeout=0.1)
+
+
+def test_dry_run(tmp_path: Path):
+    make_plugin(tmp_path, "p", perms=["fs.write"])
+    loader = PluginLoader(plugin_dir=tmp_path, dry_run=True)
+    loader.discover()
+    loader.execute("p", {"text": "x"})
+    assert not (tmp_path / "p.out").exists()
+
+
+def test_audit_log(tmp_path: Path, caplog: pytest.LogCaptureFixture):
     make_plugin(tmp_path, "p")
     loader = PluginLoader(plugin_dir=tmp_path)
     loader.discover()
     caplog.set_level(logging.INFO)
-    loader.execute("p", {})
-    assert any(r.action == "execute" for r in caplog.records)  # type: ignore[attr-defined]
+    loader.execute("p", {"text": "hi"})
+    assert any("plugin-execute" in r.message or r.msg == "plugin-execute" for r in caplog.records)
 
 
-def test_config_schema_validation(tmp_path: Path):
-    make_plugin(tmp_path, "p", schema={"count": "int"})
+def test_shutdown_called(tmp_path: Path):
+    make_plugin(tmp_path, "p")
     loader = PluginLoader(plugin_dir=tmp_path)
-    with pytest.raises(ValidationError):
-        loader.discover(configs={"p": {"count": "bad"}})
+    loader.discover()
+    loader.shutdown_all()
+    assert getattr(loader.plugins["p"], "closed", False)

--- a/tests/test_cli_voice_shell.py
+++ b/tests/test_cli_voice_shell.py
@@ -1,16 +1,16 @@
 from typer.testing import CliRunner
-import importlib
+
 import main
 
 
 def test_voice_shell_timeout(monkeypatch):
     calls = []
 
-    def dummy_voice_shell(*, timeout=None, model_path=None, wakeword="axon"):
-        calls.append(timeout)
+    def dummy_execute(name: str, data: dict) -> None:
+        calls.append(data["timeout"])
 
-    module = importlib.import_module("plugins.voice_shell")
-    monkeypatch.setattr(module, "voice_shell", dummy_voice_shell)
+    monkeypatch.setattr(main.plugin_loader, "discover", lambda: None)
+    monkeypatch.setattr(main.plugin_loader, "execute", dummy_execute)
     runner = CliRunner()
     result = runner.invoke(main.app, ["voice-shell", "--timeout", "5"])
     assert result.exit_code == 0

--- a/tests/test_plugin_context.py
+++ b/tests/test_plugin_context.py
@@ -41,7 +41,10 @@ def test_demo_plugin(monkeypatch):
     monkeypatch.setattr(context, "goal_tracker", goals)
     loader = PluginLoader()
     loader.discover()
-    result = loader.execute("remember_goal", {"key": "topic", "value": "fact", "goal": "goal text"})
-    assert result == "ok"
+    result = loader.execute(
+        "remember_goal",
+        {"key": "topic", "value": "fact", "goal": "goal text"},
+    )
+    assert result.result == "ok"
     assert mem.add_calls
     assert goals.calls


### PR DESCRIPTION
## Summary
- introduce manifest loader with pydantic validation
- add generic Plugin base with permission guards
- update PluginLoader with auditing, dry-run and timeout support
- migrate built-in plugins and manifests to v2 format
- expose plugin CLI helpers
- expand plugin tests to cover new functionality

## Testing
- `poetry run ruff check .`
- `poetry run mypy . --show-error-codes`
- `poetry run pytest -q tests/plugins tests/test_cli_voice_shell.py tests/test_plugin_context.py`

------
https://chatgpt.com/codex/tasks/task_e_6882ad7ad690832b9bd5eddcf29d7c9a