### PR TITLE
Fix memory unlock handling and add test

### DIFF
--- a/axon/memory/base.py
+++ b/axon/memory/base.py
@@ -37,3 +37,7 @@ class MemoryStore(ABC):
     @abstractmethod
     def lock(self, record_id: str) -> None:
         """Lock a record from modification."""
+
+    @abstractmethod
+    def unlock(self, record_id: str) -> None:
+        """Unlock a record so it can be modified."""

--- a/axon/memory/json_store.py
+++ b/axon/memory/json_store.py
@@ -111,3 +111,10 @@ class JSONFileMemoryStore(MemoryStore):
             raise KeyError(record_id)
         rec.locked = True
         self._save()
+
+    def unlock(self, record_id: str) -> None:
+        rec = self._records.get(record_id)
+        if rec is None:
+            raise KeyError(record_id)
+        rec.locked = False
+        self._save()

--- a/memory/memory_handler.py
+++ b/memory/memory_handler.py
@@ -94,7 +94,9 @@ class MemoryHandler:
         if locked:
             self.repo.store.lock(key)
             return True
-        return False
+        # Allow unlocking previously locked records
+        self.repo.store.unlock(key)
+        return True
 
     def close_connection(self) -> None:
         pass

--- a/tests/memory/test_store.py
+++ b/tests/memory/test_store.py
@@ -51,3 +51,13 @@ def test_disk_persistence(tmp_path):
 
     repo2 = MemoryRepository(JSONFileMemoryStore(str(path)))
     assert repo2.store.get(rid) is not None
+
+
+def test_unlock(tmp_path):
+    store = JSONFileMemoryStore(str(tmp_path / "u.json"))
+    repo = MemoryRepository(store)
+    rid = repo.remember_fact("lock-me")
+    store.lock(rid)
+    assert store.get(rid).locked
+    store.unlock(rid)
+    assert not store.get(rid).locked


### PR DESCRIPTION
## Summary
- allow unlocking memory records by adding unlock methods
- support unlocking in `MemoryHandler`
- test unlocking behavior

## Reasoning
The API claims memory facts can be locked or unlocked, but the
implementation only supported locking. An `unlock` method was added
to the memory store interface and JSON file implementation. The
`MemoryHandler` now calls this when `locked` is false. A new unit test
verifies unlocking works. `make verify` confirms all tests pass.

------
https://chatgpt.com/codex/tasks/task_e_688367d43e50832bb93daedb40ab0301