### PR TITLE
Improve MemoryHandler update logic

### DIFF
--- a/axon/memory/base.py
+++ b/axon/memory/base.py
@@ -37,3 +37,7 @@ class MemoryStore(ABC):
     @abstractmethod
     def lock(self, record_id: str) -> None:
         """Lock a record from modification."""
+
+    @abstractmethod
+    def unlock(self, record_id: str) -> None:
+        """Unlock a record so it can be modified."""

--- a/axon/memory/json_store.py
+++ b/axon/memory/json_store.py
@@ -111,3 +111,10 @@ class JSONFileMemoryStore(MemoryStore):
             raise KeyError(record_id)
         rec.locked = True
         self._save()
+
+    def unlock(self, record_id: str) -> None:
+        rec = self._records.get(record_id)
+        if rec is None:
+            raise KeyError(record_id)
+        rec.locked = False
+        self._save()

--- a/memory/memory_handler.py
+++ b/memory/memory_handler.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Optional
+from datetime import datetime
+from typing import Any, Optional
 
 from axon.memory import MemoryRepository
 
@@ -64,14 +65,16 @@ class MemoryHandler:
         domain: Optional[str] = None,
         tags: Iterable[str] | None = None,
     ) -> None:
-        metadata = {"identity": identity} if identity else None
-        self.repo.store.update(
-            key,
-            content=value,
-            scope=domain or thread_id,
-            tags=list(tags) if tags else [],
-            metadata=metadata,
-        )
+        update_fields: dict[str, Any] = {
+            "content": value,
+            "scope": domain or thread_id,
+            "updated_at": datetime.utcnow(),
+        }
+        if tags is not None:
+            update_fields["tags"] = list(tags)
+        if identity is not None:
+            update_fields["metadata"] = {"identity": identity}
+        self.repo.store.update(key, **update_fields)
 
     def delete_fact(self, thread_id: str, key: str) -> bool:
         return self.repo.store.delete(key)
@@ -94,7 +97,9 @@ class MemoryHandler:
         if locked:
             self.repo.store.lock(key)
             return True
-        return False
+        # Allow unlocking previously locked records
+        self.repo.store.unlock(key)
+        return True
 
     def close_connection(self) -> None:
         pass

--- a/tests/memory/test_handler.py
+++ b/tests/memory/test_handler.py
@@ -1,0 +1,28 @@
+from axon.memory import JSONFileMemoryStore, MemoryRepository
+from memory.memory_handler import MemoryHandler
+
+
+def test_update_preserves_fields(tmp_path):
+    store = JSONFileMemoryStore(str(tmp_path / "h.json"))
+    handler = MemoryHandler()
+    handler.repo = MemoryRepository(store)
+
+    handler.add_fact("t1", "r1", "hello", identity="bob", tags=["a", "b"])
+
+    handler.update_fact("t1", "r1", "bye")
+    rec = store.get("r1")
+    assert rec.content == "bye"
+    assert rec.tags == ["a", "b"]
+    assert rec.metadata == {"identity": "bob"}
+
+
+def test_update_sets_timestamp(tmp_path):
+    store = JSONFileMemoryStore(str(tmp_path / "u.json"))
+    handler = MemoryHandler()
+    handler.repo = MemoryRepository(store)
+
+    handler.add_fact("t1", "r1", "hello")
+    before = store.get("r1").updated_at
+    handler.update_fact("t1", "r1", "bye")
+    after = store.get("r1").updated_at
+    assert after > before

--- a/tests/memory/test_store.py
+++ b/tests/memory/test_store.py
@@ -51,3 +51,13 @@ def test_disk_persistence(tmp_path):
 
     repo2 = MemoryRepository(JSONFileMemoryStore(str(path)))
     assert repo2.store.get(rid) is not None
+
+
+def test_unlock(tmp_path):
+    store = JSONFileMemoryStore(str(tmp_path / "u.json"))
+    repo = MemoryRepository(store)
+    rid = repo.remember_fact("lock-me")
+    store.lock(rid)
+    assert store.get(rid).locked
+    store.unlock(rid)
+    assert not store.get(rid).locked


### PR DESCRIPTION
## Summary
- preserve tags and metadata when updating facts
- test MemoryHandler update behavior
- unlock records via store implementation
- update `updated_at` timestamp on fact updates

## Reasoning
While reviewing locking logic, a bug was found in `MemoryHandler.update_fact`. If
`tags` or `identity` were omitted, the method passed empty values to the store,
clearing existing data. The fix builds an update dictionary only with explicitly
provided fields so existing tags and metadata remain untouched. A unit test
verifies the new behavior. Additional scan revealed the updated timestamp was
never refreshed on updates, so the handler now sets `updated_at` using
`datetime.utcnow()`. Tests confirm the timestamp advances.


------
https://chatgpt.com/codex/tasks/task_e_688367d43e50832bb93daedb40ab0301