### PR TITLE
docs(readme): clarify Postgres optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Ideas that sound vague ("someday I might...") are marked as **deferred** and
 trigger periodic reminder prompts. They can be listed via
 `/goals/{thread_id}/deferred`.
 
+<!-- NOTE: document optional Postgres and health endpoint -->
+Axon gracefully disables goal-tracking if Postgres isn’t available. Start
+Postgres to re-enable the feature. Use `GET /health` to inspect service status.
+
 ## Docker Compose
 
 The repository includes a `docker-compose.yml` for running Axon and its

--- a/axon/__init__.py
+++ b/axon/__init__.py
@@ -1,0 +1,1 @@
+# NOTE: make axon a regular package

--- a/axon/api/__init__.py
+++ b/axon/api/__init__.py
@@ -1,0 +1,1 @@
+# NOTE: API package placeholder

--- a/axon/api/routes/system.py
+++ b/axon/api/routes/system.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from axon.utils.health import service_status
+
+router = APIRouter()
+
+
+@router.get("/health", tags=["system"])
+async def health():
+    """Return the per-process service status."""
+    # NOTE: expose service_status for each worker
+    return service_status.__dict__

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from agent.pasteback_handler import PastebackHandler
 from agent.plugin_loader import AVAILABLE_PLUGINS, load_plugins
 from agent.reminder import MemoryLike, ReminderManager
 from agent.session_tracker import SessionTracker
+from axon.api.routes.system import router as system_router  # NOTE: health route
 from axon.config.settings import settings
 from axon.utils.health import check_service, service_status
 from memory.memory_handler import MemoryHandler
@@ -122,6 +123,7 @@ app = FastAPI(
     description="The backend service for the Axon project, handling API requests and WebSocket connections.",
     version="0.1.0",
 )
+app.include_router(system_router)
 app.add_middleware(
     RateLimiterMiddleware,
     limit=settings.app.rate_limit_per_minute,

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+# ruff: noqa: E402
+
+root_dir = Path(__file__).resolve().parent
+sys.path.insert(0, str(root_dir / "axon"))  # NOTE: ensure package import  # noqa: E402
+
+import pytest
+from utils import health as health_mod
+
+service_status = health_mod.service_status
+
+
+def pytest_collection_modifyitems(config, items):
+    skip_db = pytest.mark.skip(reason="DB service unavailable")
+    for item in items:
+        markers = {m.name for m in item.iter_markers()}
+        if "needs_postgres" in markers and not service_status.postgres:
+            item.add_marker(skip_db)
+        if "needs_qdrant" in markers and not service_status.qdrant:
+            item.add_marker(skip_db)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,3 +14,7 @@ poetry install --with calendar,postgres,vector,notify
 
 On first run Axon will copy `config/settings.example.yaml` to
 `config/settings.yaml` if the file is missing.
+
+If you start Axon without Postgres, goal-tracking is silently disabled. You can
+check running services via `GET /health` which reports Postgres, Qdrant and
+Redis status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 license = "MIT"
 name = "axon"
-version = "0.2.0"
+version = "0.2.1"
 description = "Axon Project"
 authors = ["Your Name <you@example.com>"]
 package-mode = false
 
 [project]
 name = "axon"
-version = "0.2.0"
+version = "0.2.1"
 description = "Axon Project"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/tests/test_goal_deferred.py
+++ b/tests/test_goal_deferred.py
@@ -1,7 +1,11 @@
 import pytest
 
 from agent.goal_tracker import HAS_PSYCOPG2, GoalTracker
-from axon.utils.health import service_status
+
+pytestmark = pytest.mark.needs_postgres  # NOTE: auto-skip via conftest
+
+if not HAS_PSYCOPG2:
+    pytest.skip("psycopg2 missing", allow_module_level=True)
 
 
 class DummyCursor:
@@ -37,8 +41,6 @@ class DummyConn:
 
 
 def test_add_goal_marks_deferred(monkeypatch):
-    if not HAS_PSYCOPG2 or not service_status.postgres:
-        pytest.skip("postgres unavailable")
     cur = DummyCursor()
     conn = DummyConn(cur)
     monkeypatch.setattr("psycopg2.connect", lambda *a, **k: conn)
@@ -50,8 +52,6 @@ def test_add_goal_marks_deferred(monkeypatch):
 
 
 def test_list_deferred(monkeypatch):
-    if not HAS_PSYCOPG2 or not service_status.postgres:
-        pytest.skip("postgres unavailable")
     cur = DummyCursor()
     cur.fetchall_result = [(1, "Someday I might travel", False, None, True, 0, None)]
     conn = DummyConn(cur)
@@ -62,8 +62,6 @@ def test_list_deferred(monkeypatch):
 
 
 def test_priority_and_deadline(monkeypatch):
-    if not HAS_PSYCOPG2 or not service_status.postgres:
-        pytest.skip("postgres unavailable")
     from datetime import datetime
 
     cur = DummyCursor()
@@ -77,8 +75,6 @@ def test_priority_and_deadline(monkeypatch):
 
 
 def test_deferred_prompt(monkeypatch):
-    if not HAS_PSYCOPG2 or not service_status.postgres:
-        pytest.skip("postgres unavailable")
     called = []
 
     class DummyNotifier:

--- a/tests/test_goal_detection.py
+++ b/tests/test_goal_detection.py
@@ -3,6 +3,7 @@ from agent.goal_tracker import GoalTracker
 
 def test_detect_goal_creates_entry(monkeypatch):
     tracker = GoalTracker.__new__(GoalTracker)
+    tracker.conn = object()  # NOTE: pretend DB connected
     calls = []
 
     def dummy_add(thread_id, text, identity=None):

--- a/tests/test_goaltracker_fallback.py
+++ b/tests/test_goaltracker_fallback.py
@@ -1,0 +1,16 @@
+from agent.goal_tracker import GoalTracker
+from axon.utils.health import service_status
+
+
+def test_goaltracker_no_postgres(monkeypatch):
+    monkeypatch.setattr(service_status, "postgres", False)
+    tracker = GoalTracker(db_uri="postgresql://ignore")
+    tracker.add_goal("t1", "do things")
+    assert not tracker.detect_and_add_goal("t1", "I want to run")  # NOTE: disabled
+    assert tracker.list_goals("t1") == []
+    assert tracker.list_deferred_goals("t1") == []
+    tracker.complete_goal(1)
+    assert tracker.delete_goals("t1") == 0
+    tracker.start_deferred_prompting("t1", interval_seconds=0.01)
+    assert tracker._prompt_timer is None
+    tracker.stop_deferred_prompting()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -15,3 +15,22 @@ def test_backend_startup_warning(monkeypatch, caplog):
 
     importlib.reload(bm)
     assert any("unreachable" in r.message for r in caplog.records)
+
+
+def test_default_ports(monkeypatch):
+    created = []
+
+    class Dummy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def fake_conn(addr, timeout=2):
+        created.append(addr)
+        return Dummy()
+
+    monkeypatch.setattr(health.socket, "create_connection", fake_conn)
+    assert health.check_service("mqtt://broker")
+    assert created[0] == ("broker", 1883)

--- a/tests/test_vector_store_identity.py
+++ b/tests/test_vector_store_identity.py
@@ -4,6 +4,8 @@ import pytest
 
 from memory.vector_store import HAS_QDRANT, VectorStore
 
+pytestmark = pytest.mark.needs_qdrant  # NOTE: auto-skip via conftest
+
 if HAS_QDRANT:
     from qdrant_client.http import models
 else:  # pragma: no cover - optional qdrant


### PR DESCRIPTION
## Reasoning
- documented that goal tracking auto-disables without Postgres and added `/health` endpoint docs
- centralised default ports table with MQTT entry and exposed a new `/health` route
- GoalTracker disabled mode now returns consistent types and auto-skip markers are handled by `conftest`

## Testing
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884e3f1dd08832bbbb4e1328ff4c611