### PR TITLE
Fix invalid JSON in frontend package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,12 @@
         "build": "tsc -b && vite build",
         "lint": "eslint .",
         "preview": "vite preview",
-        "type-check": "tsc --noEmit",
+        "type-check": "tsc --noEmit"
     },
-    "dependencies": {"react": "^19.1.0", "react-dom": "^19.1.0"},
+    "dependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+    },
     "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@types/react": "^19.1.8",
@@ -23,6 +26,6 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4",
-        "vite-plugin-pwa": "^1.0.1",
-    },
+        "vite-plugin-pwa": "^1.0.1"
+    }
 }


### PR DESCRIPTION
## Summary
- remove trailing commas in frontend/package.json so npm can parse it

## Testing
- `make verify`
- `npm ci --no-fund --no-audit` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*
- `npm install --no-fund --no-audit`
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e1d4da13c832b9112375b5fdceb96