### PR TITLE
Use bash TCP healthcheck for qdrant

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     volumes:
       - qdrant_data:/qdrant/storage
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6333/collections"]
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/6333'"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- replace curl-based qdrant healthcheck with bash /dev/tcp probe

## Reasoning
- qdrant image lacked curl, causing the previous health check to mark the container unhealthy

## Testing
- `make verify` (ruff, mypy, pytest)


------
https://chatgpt.com/codex/tasks/task_e_688eb21200d8832b8fb7d53280293a53