### PR TITLE
feat: allow local LLM server configuration

### DIFF
--- a/agent/llm_router.py
+++ b/agent/llm_router.py
@@ -27,9 +27,19 @@ class LLMRouter:
         """Return an assistant configured for the requested model."""
         if self.assistant is None or model != self.model:
             tool_names = list(TOOL_REGISTRY.keys())
+            llm_cfg: dict[str, Any] = {"model": model}
+            if settings.llm.model_server:
+                llm_cfg.update(
+                    {
+                        "model_type": "oai",
+                        "model_server": settings.llm.model_server,
+                    }
+                )
+            else:
+                llm_cfg["model_type"] = "transformers"
             self.assistant = Assistant(
                 function_list=tool_names,
-                llm={"model": model, "model_type": "transformers"},
+                llm=llm_cfg,
                 generate_cfg=settings.llm.qwen_agent_generate_cfg,
             )
             self.model = model

--- a/axon/config/settings.py
+++ b/axon/config/settings.py
@@ -67,6 +67,7 @@ class LlmSettings(BaseModel):
     """LLM configuration."""
 
     default_local_model: str = "qwen3:8b"
+    model_server: str | None = None
     qwen_agent_generate_cfg: dict[str, Any] | None = None
 
 

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -7,6 +7,7 @@ database:
 
 llm:
   default_local_model: "qwen3:8b"
+  model_server: "http://localhost:11434/v1"
   qwen_agent_generate_cfg:
     fncall_prompt_type: "nous"
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -15,6 +15,7 @@ Example `settings.yaml` snippet:
 ```yaml
 llm:
   default_local_model: "mistral:7b"
+  model_server: "http://localhost:11434/v1"
 ```
 
 Restart the backend after changing settings so the new model is loaded.
@@ -37,6 +38,7 @@ Pass the prompt template through `generate_cfg` when creating the assistant.
 ```yaml
 llm:
   default_local_model: "qwen3:8b"
+  model_server: "http://localhost:11434/v1"  # point to your Ollama host
   qwen_agent_generate_cfg:
     fncall_prompt_type: "nous"
 ```


### PR DESCRIPTION
## Summary
- allow configuring an OpenAI-style local endpoint via `settings.llm.model_server`
- update `LLMRouter` to use the configured server when present
- document new `model_server` option in example config and docs

## Testing
- `poetry run ruff check . --fix`
- `poetry run ruff format .`
- `make verify`


------
https://chatgpt.com/codex/tasks/task_e_688ebc41f53c832b8c3f8115ac2bf6a1