### PR TITLE
Use OpenRouter API by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ POSTGRES_DB=axon_db
 # For development, not used by app
 PGADMIN_DEFAULT_EMAIL=admin@example.com
 PGADMIN_DEFAULT_PASSWORD=admin
+
+# OpenRouter API key
+OPENAI_API_KEY=sk-your-openrouter-key

--- a/agent/llm_router.py
+++ b/agent/llm_router.py
@@ -1,4 +1,4 @@
-"""LLM router integrating Qwen-Agent."""
+"""LLM router integrating OpenRouter via Qwen-Agent."""
 
 from __future__ import annotations
 
@@ -15,12 +15,12 @@ from .response_shaper import ResponseShaper
 
 
 class LLMRouter:
-    """Route prompts through a local Qwen-Agent assistant."""
+    """Route prompts through an OpenRouter-backed Qwen-Agent assistant."""
 
     def __init__(self, model: str | None = None) -> None:
-        """Create the assistant using Qwen3 and registered tools."""
+        """Create the assistant using OpenRouter and registered tools."""
 
-        self.model = model or "Qwen/Qwen3-4B-Instruct"
+        self.model = model or "openrouter/horizon-beta"
         self.assistant: Assistant | None = None
 
     def _ensure_assistant(self, model: str) -> Assistant:

--- a/backend/main.py
+++ b/backend/main.py
@@ -173,7 +173,7 @@ async def list_mcp_tools():
 @app.get("/models")
 async def list_models():
     """Return available local models."""
-    return {"models": [settings.llm.default_local_model, "mock-model"]}
+    return {"models": [settings.llm.default_local_model, "z-ai/glm-4.5-air:free"]}
 
 
 @app.post("/sessions/login")

--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -6,8 +6,8 @@ database:
   redis_url: "redis://localhost:6379/0"
 
 llm:
-  default_local_model: "qwen3:8b"
-  model_server: "http://localhost:11434/v1"
+  default_local_model: "openrouter/horizon-beta"
+  model_server: "https://openrouter.ai/api/v1"
   qwen_agent_generate_cfg:
     fncall_prompt_type: "nous"
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,22 +1,31 @@
 # Customising Models
 
 LLM calls are routed through `agent.llm_router.LLMRouter`. The router builds a
-`qwen_agent.agents.Assistant` using the open‑source **Qwen3** model and all
-registered tools. When the input is very long or the local call fails the router
-returns a JSON payload suggesting a cloud model instead.
+`qwen_agent.agents.Assistant` with all registered tools. By default the
+assistant connects to the **OpenRouter** API, but it can also target a local
+OpenAI‑compatible server such as Ollama. When the input is very long or the
+local call fails the router returns a JSON payload suggesting a cloud model
+instead.
 
-The default model used by the backend is configured in `config/settings.yaml` under `llm.default_local_model`. Update this value to switch models globally.
+The default model used by the backend is configured in `config/settings.yaml`
+under `llm.default_local_model`. Update this value to switch models globally.
 
 To change the model you can pass a different model name when creating
 `LLMRouter` in `backend/main.py` or update `settings.llm.default_local_model`.
 
-Example `settings.yaml` snippet:
+Example `settings.yaml` snippet for OpenRouter:
 
 ```yaml
 llm:
-  default_local_model: "mistral:7b"
-  model_server: "http://localhost:11434/v1"
+  default_local_model: "openrouter/horizon-beta"
+  model_server: "https://openrouter.ai/api/v1"
 ```
+
+Set the `OPENAI_API_KEY` environment variable with your OpenRouter API key
+before starting the backend.
+
+The backend also exposes the free `z-ai/glm-4.5-air:free` model as a secondary
+option.
 
 Restart the backend after changing settings so the new model is loaded.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
   const [newTags, setNewTags] = useState('');
   const [cloudPrompt, setCloudPrompt] = useState<{model: string; prompt: string} | null>(null);
   const [pasteValue, setPasteValue] = useState('');
-  const [selectedModel, setSelectedModel] = useState('qwen3:8b');
+  const [selectedModel, setSelectedModel] = useState('openrouter/horizon-beta');
   const ws = useRef<WebSocket | null>(null);
   const sendMcp = (tool: string, args: Record<string, unknown>) => {
     if (ws.current?.readyState !== WebSocket.OPEN) return;
@@ -136,8 +136,8 @@ function App() {
             placeholder="Type your message..."
           />
           <select value={selectedModel} onChange={(e)=>setSelectedModel(e.target.value)}>
-            <option value="qwen3:8b">qwen3:8b</option>
-            <option value="mock-model">mock-model</option>
+            <option value="openrouter/horizon-beta">openrouter/horizon-beta</option>
+            <option value="z-ai/glm-4.5-air:free">z-ai/glm-4.5-air:free</option>
           </select>
           <button onClick={handleSendMessage}>Send</button>
           <button onClick={() => sendMcp('time', {command: 'now'})}>Time</button>


### PR DESCRIPTION
## Summary
- default the LLM router to OpenRouter's horizon-beta model and expose z-ai/glm-4.5-air:free as a secondary option
- point example settings and UI to OpenRouter API
- document the new default and secondary OpenRouter models in `docs/models.md`
- document OpenRouter API key requirement in `.env.example` and model docs

## Testing
- `make verify`
- `npm install --no-fund --no-audit`
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_688f5712db60832b93d13c1962e7693f